### PR TITLE
Document subagent index and GitHub workflow

### DIFF
--- a/agents/agents.md
+++ b/agents/agents.md
@@ -1,0 +1,31 @@
+# Índice maestro de subagentes
+
+> 🧭 **Comentario orientativo:** Este índice centraliza todos los perfiles operativos del proyecto para que puedas localizar rápidamente a la persona o subagente virtual adecuado.
+
+## ¿Qué es un subagente?
+Un subagente es una especialización documentada que encapsula responsabilidades, entradas y salidas esperadas dentro del flujo colaborativo. Estos perfiles sirven como guías vivas para distribuir trabajo, automatizar tareas y mantener claridad sobre quién hace qué.
+
+## Cómo utilizar este índice
+1. Identifica el tipo de tarea (generar código, auditar, probar, coordinar, operar GitHub, etc.).
+2. Selecciona el subagente correspondiente para conocer su alcance, límites y artefactos de salida.
+3. Sigue los enlaces para revisar los detalles completos y asegurarte de proveer los inputs adecuados.
+
+> ✅ **Nota visual para la PR:** Cada subagente incluye ahora un comentario de enlace cruzado que apunta de regreso a este índice para reforzar la trazabilidad documental.
+
+## Mapa de subagentes activos
+| Subagente | Rol | Responsabilidades clave | Documento |
+|-----------|-----|-------------------------|-----------|
+| Auditor Backend | Auditor | Revisar calidad técnica, riesgos y cumplimiento de estándares en servicios backend. | [auditor_backend.md](./auditor_backend.md) |
+| Auditor Frontend | Auditor | Garantizar accesibilidad, consistencia visual y mantenibilidad del frontend. | [auditor_frontend.md](./auditor_frontend.md) |
+| Generador Backend | Generador | Implementar APIs, lógica de negocio y persistencia con patrones establecidos. | [generador_backend.md](./generador_backend.md) |
+| Generador Frontend | Generador | Construir componentes de UI accesibles y alineados a diseño. | [generador_frontend.md](./generador_frontend.md) |
+| Generador Infraestructura | Generador | Diseñar infraestructura como código, pipelines y prácticas de resiliencia. | [generador_infra.md](./generador_infra.md) |
+| Integrador | Integrador | Coordinar merges, despliegues y comunicación entre equipos. | [integrador.md](./integrador.md) |
+| Tester Backend | Tester | Diseñar y ejecutar pruebas backend (unitarias, integración, performance). | [tester_backend.md](./tester_backend.md) |
+| Tester Frontend | Tester | Validar UX y estabilidad mediante pruebas unitarias y E2E. | [tester_frontend.md](./tester_frontend.md) |
+| Gestor GitHub | Coordinador operativo | Administrar issues/PRs, aplicar labels y sincronizar el repositorio con las guías. | [github_agent.md](./github_agent.md) |
+
+## Comentarios finales
+- Mantén este índice actualizado cada vez que nazca o cambie un subagente.
+- Si detectas huecos en la cobertura de roles, crea un nuevo archivo en `/agents` siguiendo el formato existente y agrégalo a la tabla.
+- Documenta siempre los ejemplos de uso para que los equipos sepan cómo interactuar con cada perfil.

--- a/agents/auditor_backend.md
+++ b/agents/auditor_backend.md
@@ -1,5 +1,7 @@
 # Subagente Auditor Backend
 
+> 🗂️ **Nota rápida:** Este perfil está enlazado desde el índice maestro [`agents/agents.md`](./agents.md) para que cualquier colaborador lo encuentre en segundos.
+
 ## Identificador del subagente
 - `auditor_backend`
 

--- a/agents/auditor_frontend.md
+++ b/agents/auditor_frontend.md
@@ -1,5 +1,7 @@
 # Subagente Auditor Frontend
 
+> 🗂️ **Nota rápida:** Este perfil está enlazado desde el índice maestro [`agents/agents.md`](./agents.md) para facilitar el acceso directo a sus responsabilidades.
+
 ## Identificador del subagente
 - `auditor_frontend`
 

--- a/agents/generador_backend.md
+++ b/agents/generador_backend.md
@@ -1,5 +1,7 @@
 # Subagente Generador Backend
 
+> 🗂️ **Nota rápida:** Consulta el índice maestro en [`agents/agents.md`](./agents.md) para ver cómo este rol se coordina con otros subagentes.
+
 ## Identificador del subagente
 - `generador_backend`
 

--- a/agents/generador_frontend.md
+++ b/agents/generador_frontend.md
@@ -1,5 +1,7 @@
 # Subagente Generador Frontend
 
+> 🗂️ **Nota rápida:** Puedes ubicar este perfil y sus enlaces relacionados en [`agents/agents.md`](./agents.md), el índice consolidado de subagentes.
+
 ## Identificador del subagente
 - `generador_frontend`
 

--- a/agents/generador_infra.md
+++ b/agents/generador_infra.md
@@ -1,5 +1,7 @@
 # Subagente Generador Infraestructura
 
+> 🗂️ **Nota rápida:** Este documento está referenciado desde [`agents/agents.md`](./agents.md) para que el equipo identifique rápidamente al responsable de infraestructura.
+
 ## Identificador del subagente
 - `generador_infra`
 

--- a/agents/github_agent.md
+++ b/agents/github_agent.md
@@ -1,0 +1,58 @@
+# Subagente Gestor GitHub
+
+> 🗂️ **Nota rápida:** Este nuevo perfil queda registrado en [`agents/agents.md`](./agents.md) como punto único de referencia para las operaciones en GitHub.
+
+## Identificador del subagente
+- `github_agent`
+
+## Tipo
+- coordinador operativo de repositorio
+
+## Propósito
+- Gestionar issues, pull requests, labels y automatizaciones vinculadas al flujo de trabajo de GitHub del proyecto.
+
+## Cuándo debe activarse
+- Al crear, actualizar o cerrar issues y pull requests que requieran clasificación y seguimiento formal.
+- Cuando se necesita verificar la existencia de labels definidas en [`docs/GITHUB_LABELS.md`](../docs/GITHUB_LABELS.md).
+- Antes de publicar reportes de estado que dependan de métricas de labels (por ejemplo, cuántos issues `priority/P1-high`).
+
+## Inputs esperados
+- Descripción del issue o pull request (título, cuerpo, autores implicados, área impactada).
+- Contexto de prioridad, tamaño estimado y estado actual del trabajo.
+- Inventario actual de labels disponibles en el repositorio mediante la API de GitHub.
+
+## Outputs esperados
+- Issues y pull requests con labels consistentes según la guía centralizada.
+- Creación automática de labels faltantes alineadas con [`docs/GITHUB_LABELS.md`](../docs/GITHUB_LABELS.md).
+- Registro (comentarios o notas internas) de las acciones realizadas: etiquetas aplicadas, creaciones nuevas y cualquier incidencia detectada.
+
+## Lógica de labels integrada
+> ✅ **Comentario clave:** Todo el comportamiento de etiquetado replica fielmente la tabla y las reglas definidas en [`docs/GITHUB_LABELS.md`](../docs/GITHUB_LABELS.md).
+
+1. Leer la tabla de labels de la documentación y construir un diccionario `{nombre: {categoría, descripción, color}}`.
+2. Consultar las labels existentes en el repositorio (vía API REST o GraphQL de GitHub).
+3. Crear automáticamente las labels ausentes con el color hexadecimal exacto y la descripción en español.
+4. Aplicar al menos una label `type/*`, una `area/*` y una `priority/*` a cada issue o PR.
+5. Añadir labels `status/*` y `size/*` cuando el input proporcione información de estado o esfuerzo.
+6. Registrar en un comentario de seguimiento qué labels se aplicaron o actualizaron, incluyendo fecha y autor de la acción.
+
+## Ejemplos de uso documentados
+> 💡 **Tip práctico:** Adapta estos escenarios a tus necesidades, pero mantén la coherencia con las combinaciones recomendadas.
+
+- **Issue de bug crítico en backend**
+  - Inputs: Error 500 en endpoint de pagos, bloquea el release, esfuerzo estimado `S`.
+  - Acciones: Verifica existencia de labels y crea las faltantes, luego aplica `type/bug`, `area/backend`, `priority/P0-blocker`, `status/blocked`, `size/S`.
+  - Resultado: Issue queda listo para priorización urgente con trazabilidad inmediata.
+- **Pull request de nueva funcionalidad frontend**
+  - Inputs: PR agrega vista de panel de control, impacto alto, progreso activo, estimación `M`.
+  - Acciones: Aplica `type/feature`, `area/frontend`, `priority/P1-high`, `status/in-progress`, `size/M` y añade comentario documentando la asignación.
+  - Resultado: El PR aparece correctamente categorizado en los tableros del proyecto.
+
+## Checklist operativo
+- [ ] Confirmar lectura actualizada de [`docs/GITHUB_LABELS.md`](../docs/GITHUB_LABELS.md).
+- [ ] Validar y sincronizar el catálogo de labels con GitHub antes de etiquetar.
+- [ ] Notificar al equipo cuando se creen nuevas labels o cambien colores/descripciones.
+- [ ] Mantener historial de acciones para auditoría posterior.
+
+## Notas adicionales
+> 📘 **Comentario de mantenimiento:** Si GitHub introduce nuevas categorías de labels o la guía del proyecto se amplía, este subagente debe actualizarse junto con el índice para reflejar los cambios.

--- a/agents/integrador.md
+++ b/agents/integrador.md
@@ -1,5 +1,7 @@
 # Subagente Integrador
 
+> 🗂️ **Nota rápida:** Encuentra el contexto completo de coordinación en [`agents/agents.md`](./agents.md), donde este rol aparece junto al resto de subagentes.
+
 ## Identificador del subagente
 - `integrador`
 

--- a/agents/tester_backend.md
+++ b/agents/tester_backend.md
@@ -1,5 +1,7 @@
 # Subagente Tester Backend
 
+> 🗂️ **Nota rápida:** Consulta [`agents/agents.md`](./agents.md) para ver cómo este rol de QA se alinea con otros subagentes y flujos del proyecto.
+
 ## Identificador del subagente
 - `tester_backend`
 

--- a/agents/tester_frontend.md
+++ b/agents/tester_frontend.md
@@ -1,5 +1,7 @@
 # Subagente Tester Frontend
 
+> 🗂️ **Nota rápida:** Este perfil y sus dependencias están mapeados en [`agents/agents.md`](./agents.md) para agilizar las consultas de QA.
+
 ## Identificador del subagente
 - `tester_frontend`
 


### PR DESCRIPTION
## Summary
- add an index in `agents/agents.md` explaining the subagent system and linking all roles
- document a dedicated GitHub management subagent with label automation aligned to `docs/GITHUB_LABELS.md`
- annotate every existing subagent with cross-link notes for clearer navigation in reviews

## Testing
- not run (documentation changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917c806c56483278beed0c698c638d0)