### PR TITLE
Add ignore rules for frontend backend and deployment artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,26 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Frontend assets and local configuration
+node_modules/
+pnpm-lock.yaml
+yarn.lock
+.pnpm-store/
+.turbo/
+.vite/
+dist/
+coverage/
+storybook-static/
+frontend/.env.local
+frontend/.env.development
+frontend/.DS_Store
+
+# Backend generated files and media
+backend/*.sqlite3
+backend/staticfiles/
+backend/media/
+
+# Deployment and containerization artifacts
+docker-compose.override.yml
+*.env.docker


### PR DESCRIPTION
## Summary
- add ignore patterns for common frontend build artifacts and local configuration files
- ignore backend-generated databases and media directories
- exclude deployment-specific Docker configuration files from version control

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917e06a2a108327a3657ac4016a204a)