### PR TITLE
Add migration backlog and label bootstrap script

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Las carpetas `backend/`, `frontend/`, `backoffice/` e `infrastructure/` se incor
 
 Consulta la [guía de variables de entorno](docs/environment.md) para conocer los archivos `.env` requeridos, los valores obligatorios/opcionales por módulo y las recomendaciones de sincronización con GitHub Actions y Dokploy.
 
+## Backlog de migración y labels
+- Los issues listos para migrar el proceso de publicación están descritos en [`docs/migration_issues.md`](docs/migration_issues.md), con títulos, cuerpos y combinaciones de labels sugeridas.
+- Crea o sincroniza las labels del repositorio con la guía de [`docs/GITHUB_LABELS.md`](docs/GITHUB_LABELS.md) antes de registrar los issues.
+
 ## 9. Cómo Contribuir (para humanos y para IA)
 - Consulta primero `/docs` para entender alcance, prioridades, dependencias y reglas vigentes.
 - Revisa `/agents` para identificar subagentes relevantes y comprender sus responsabilidades.

--- a/agents/agents.md
+++ b/agents/agents.md
@@ -9,20 +9,21 @@ Un subagente es una especialización documentada que encapsula responsabilidades
 1. Identifica el tipo de tarea (generar código, auditar, probar, coordinar, operar GitHub, etc.).
 2. Selecciona el subagente correspondiente para conocer su alcance, límites y artefactos de salida.
 3. Sigue los enlaces para revisar los detalles completos y asegurarte de proveer los inputs adecuados.
+4. Añade siempre el contexto del stack: backend Django REST + PostgreSQL, frontend/backoffice React (Vite/React Admin), despliegue en compose unificado con subdominios y Dokploy.
 
 > ✅ **Nota visual para la PR:** Cada subagente incluye ahora un comentario de enlace cruzado que apunta de regreso a este índice para reforzar la trazabilidad documental.
 
-## Mapa de subagentes activos
+## Mapa de subagentes activos (alineado a los subdominios backend/frontend/backoffice)
 | Subagente | Rol | Responsabilidades clave | Documento |
 |-----------|-----|-------------------------|-----------|
-| Auditor Backend | Auditor | Revisar calidad técnica, riesgos y cumplimiento de estándares en servicios backend. | [auditor_backend.md](./auditor_backend.md) |
-| Auditor Frontend | Auditor | Garantizar accesibilidad, consistencia visual y mantenibilidad del frontend. | [auditor_frontend.md](./auditor_frontend.md) |
-| Generador Backend | Generador | Implementar APIs, lógica de negocio y persistencia con patrones establecidos. | [generador_backend.md](./generador_backend.md) |
-| Generador Frontend | Generador | Construir componentes de UI accesibles y alineados a diseño. | [generador_frontend.md](./generador_frontend.md) |
-| Generador Infraestructura | Generador | Diseñar infraestructura como código, pipelines y prácticas de resiliencia. | [generador_infra.md](./generador_infra.md) |
-| Integrador | Integrador | Coordinar merges, despliegues y comunicación entre equipos. | [integrador.md](./integrador.md) |
-| Tester Backend | Tester | Diseñar y ejecutar pruebas backend (unitarias, integración, performance). | [tester_backend.md](./tester_backend.md) |
-| Tester Frontend | Tester | Validar UX y estabilidad mediante pruebas unitarias y E2E. | [tester_frontend.md](./tester_frontend.md) |
+| Auditor Backend | Auditor | Revisar calidad técnica, riesgos y cumplimiento de estándares en servicios backend (API, JWT, PostgreSQL). | [auditor_backend.md](./auditor_backend.md) |
+| Auditor Frontend | Auditor | Garantizar accesibilidad, consistencia visual y mantenibilidad del frontend (SPA en subdominio dedicado). | [auditor_frontend.md](./auditor_frontend.md) |
+| Generador Backend | Generador | Implementar APIs, lógica de negocio y persistencia con patrones establecidos, preparando CORS y dominios cruzados. | [generador_backend.md](./generador_backend.md) |
+| Generador Frontend | Generador | Construir componentes de UI accesibles y alineados a diseño, consumiendo la API por subdominio seguro. | [generador_frontend.md](./generador_frontend.md) |
+| Generador Infraestructura | Generador | Diseñar infraestructura como código, pipelines y prácticas de resiliencia (compose unificado + Dokploy). | [generador_infra.md](./generador_infra.md) |
+| Integrador | Integrador | Coordinar merges, despliegues y comunicación entre equipos, manteniendo coherencia de subdominios. | [integrador.md](./integrador.md) |
+| Tester Backend | Tester | Diseñar y ejecutar pruebas backend (unitarias, integración, performance) considerando JWT y DB. | [tester_backend.md](./tester_backend.md) |
+| Tester Frontend | Tester | Validar UX y estabilidad mediante pruebas unitarias y E2E con el dominio de frontend/backoffice configurado. | [tester_frontend.md](./tester_frontend.md) |
 | Gestor GitHub | Coordinador operativo | Administrar issues/PRs, aplicar labels y sincronizar el repositorio con las guías. | [github_agent.md](./github_agent.md) |
 
 ## Comentarios finales

--- a/agents/auditor_backend.md
+++ b/agents/auditor_backend.md
@@ -10,21 +10,25 @@
 
 ## Propósito
 - Revisar la calidad técnica y la alineación arquitectónica del código backend antes de su integración.
+- Garantizar que la API en el subdominio backend cumpla con JWT, CORS y contratos usados por frontend y backoffice.
 
 ## Responsabilidades
 - Analizar servicios, controladores y modelos para detectar defectos o vulnerabilidades.
 - Validar que se respeten patrones de arquitectura, seguridad y rendimiento documentados en `/docs`.
 - Emitir reportes con recomendaciones priorizadas y riesgos identificados.
+- Verificar que la configuración del compose y Dokploy no rompa contratos (puertos, dominios, healthchecks).
 
 ## Inputs esperados
 - Pull requests, branches o diffs de código backend.
 - Reglas de estilo, estándares de seguridad y convenciones de `/docs`.
 - Resultados de pruebas unitarias o integraciones relevantes.
+- Variables de entorno y configuración de subdominios/CORS para validar interoperabilidad.
 
 ## Outputs esperados
 - Comentarios de revisión estructurados y accionables.
 - Evaluación de riesgos técnicos y de deuda acumulada.
 - Listado de acciones necesarias antes de la aprobación final.
+- Checklist de compatibilidad con frontend/backoffice y con el compose unificado.
 
 ## Límites y restricciones
 - No realiza merges ni despliegues.
@@ -35,6 +39,7 @@
 - Revisiones exhaustivas con trazabilidad a los requisitos.
 - Observaciones claras, justificadas y priorizadas por impacto.
 - Confirmación de que las políticas de seguridad y escalabilidad se cumplen.
+- Validación de que las rutas y CORS funcionen para los subdominios definidos y que los healthchecks pasen.
 
 ## Ejemplos de tareas típicas
 - Auditar una nueva API para asegurar que respete políticas de autenticación.

--- a/agents/auditor_frontend.md
+++ b/agents/auditor_frontend.md
@@ -10,21 +10,25 @@
 
 ## Propósito
 - Evaluar la calidad, consistencia y mantenibilidad del código de interfaz de usuario antes de su integración.
+- Confirmar que el SPA en el subdominio frontend cumple accesibilidad, seguridad (CORS/JWT) y usa la API del backend correctamente.
 
 ## Responsabilidades
 - Revisar componentes, estilos y lógica de presentación para detectar errores o inconsistencias.
 - Validar cumplimiento de estándares de accesibilidad, performance y usabilidad.
 - Emitir comentarios accionables y priorizados para el equipo generador.
+- Verificar que las configuraciones de entorno y rutas apunten al subdominio backend definido en el compose/Dokploy.
 
 ## Inputs esperados
 - Pull requests o diffs de cambios en la capa de frontend.
 - Reglas de estilo y guías documentadas en `/docs`.
 - Resultados de pruebas automáticas relevantes cuando existan.
+- URLs y variables de entorno usadas para interactuar con backend y backoffice.
 
 ## Outputs esperados
 - Informes de revisión con hallazgos, recomendaciones y niveles de severidad.
 - Checklist de criterios cumplidos y pendientes.
 - Sugerencias de mejoras o refactorizaciones futuras.
+- Validación de CORS, almacenamiento de tokens y navegación segura entre subdominios.
 
 ## Límites y restricciones
 - No implementa cambios directos en la base de código.
@@ -35,6 +39,7 @@
 - Cobertura completa de los cambios revisados, sin omitir archivos relevantes.
 - Observaciones claras, justificadas y fáciles de seguir.
 - Confirmación de que los estándares descritos en `/docs` se respetan.
+- Revisión explícita de accesibilidad y seguridad en el flujo de login/llamadas API hacia el subdominio backend.
 
 ## Ejemplos de tareas típicas
 - Auditar un nuevo diseño responsive antes de su lanzamiento.

--- a/agents/generador_backend.md
+++ b/agents/generador_backend.md
@@ -10,31 +10,37 @@
 
 ## Propósito
 - Diseñar y construir servicios backend escalables que satisfagan los requisitos de negocio y las integraciones externas.
+- Mantener la API REST (Django + DRF) accesible mediante el subdominio backend, con CORS y JWT listos para frontend y backoffice.
 
 ## Responsabilidades
 - Implementar APIs, lógica de negocio y manejo de datos según especificaciones.
 - Asegurar que el código respete patrones de arquitectura documentados en `/docs`.
 - Gestionar la persistencia y comunicación entre servicios de forma eficiente.
+- Alinear contratos, CORS y versionado con el `docker-compose` unificado y la configuración de Dokploy.
 
 ## Inputs esperados
 - Historias de usuario o requisitos técnicos para la capa de servidor.
 - Modelos de datos, diagramas o contratos API definidos previamente.
 - Código existente que requiera nuevas funcionalidades o refactorizaciones.
+- Variables de entorno y dominios de despliegue (subdominios backend/frontend/backoffice) para validar CORS y JWT.
 
 ## Outputs esperados
 - Controladores, servicios, modelos y migraciones de base de datos.
 - Notas sobre endpoints añadidos o modificados y sus dependencias.
 - Recomendaciones de pruebas automatizadas para validar la lógica implementada.
+- Checklists de CORS, auth y salud de servicios para el compose unificado y Dokploy.
 
 ## Límites y restricciones
 - No gestiona infraestructura ni despliegues en producción.
 - No modifica contratos públicos sin validar impactos con otras áreas.
 - Debe aplicar estándares de seguridad y observabilidad descritos en `/docs`.
+- No desactiva autenticación ni simplifica CORS para bypass temporal en entornos con subdominios.
 
 ## Criterios de calidad / aceptación
 - Código cubierto por pruebas básicas y con manejo robusto de errores.
 - Cumplimiento de patrones de arquitectura hexagonal o equivalente establecidos.
 - Documentación actualizada de endpoints y modelos afectados.
+- Validación explícita de CORS/JWT para los subdominios del frontend y backoffice.
 
 ## Ejemplos de tareas típicas
 - Implementar un nuevo endpoint REST con validaciones y persistencia.

--- a/agents/generador_frontend.md
+++ b/agents/generador_frontend.md
@@ -10,26 +10,31 @@
 
 ## Propósito
 - Diseñar y producir componentes de interfaz de usuario modernos y accesibles en coordinación con las especificaciones del proyecto.
+- Implementar el SPA (React + Vite) para el subdominio frontend, consumiendo la API del backend y alineando CORS/auth.
 
 ## Responsabilidades
 - Implementar vistas, componentes y estilos siguiendo guías de diseño definidas en `/docs`.
 - Traducir requisitos funcionales en experiencias interactivas en la web.
 - Mantener coherencia visual y reutilización de componentes.
+- Configurar llamadas a API y storage seguro considerando subdominios (frontend/backoffice/backend) y despliegue en compose/Dokploy.
 
 ## Inputs esperados
 - Historias de usuario o descripciones de funcionalidad para la capa visual.
 - Referencias a diseños, sistemas de componentes o estándares de accesibilidad.
 - Diffs o código existente que requiera ampliación o refactorización.
+- Variables de entorno y URLs por subdominio para desarrollar y probar con el compose unificado.
 
 ## Outputs esperados
 - Archivos de código de frontend (componentes, estilos, hooks, etc.).
 - Notas sobre decisiones tomadas y dependencias introducidas.
 - Sugerencias de pruebas de interacción para los testers.
+- Checklist de integración con el backend (dominio, CORS, JWT) y con el backoffice cuando aplique.
 
 ## Límites y restricciones
 - No aprueba ni fusiona cambios en ramas principales.
 - No define contratos de API sin coordinación con backend.
 - Debe respetar patrones arquitectónicos documentados en `/docs`.
+- No cambia configuraciones de CORS ni tokens para “hacerlo funcionar” sin coordinar con backend/infra.
 
 ## Criterios de calidad / aceptación
 - Cumplimiento de estándares de accesibilidad y rendimiento definidos.

--- a/agents/generador_infra.md
+++ b/agents/generador_infra.md
@@ -10,21 +10,25 @@
 
 ## Propósito
 - Definir y automatizar la infraestructura necesaria para desplegar y operar el proyecto de forma confiable.
+- Mantener el `docker-compose` unificado (backend, frontend y backoffice) con sus subdominios y preparar despliegues en Dokploy.
 
 ## Responsabilidades
 - Redactar plantillas de infraestructura como código y configuraciones de CI/CD.
 - Proponer mejoras de observabilidad, seguridad y resiliencia apoyándose en `/docs`.
 - Coordinar la integración de servicios externos en entornos controlados.
+- Documentar dominios, certificados, healthchecks y networking para el compose con backend/frontend/backoffice.
 
 ## Inputs esperados
 - Requisitos de despliegue, entornos y escalabilidad definidos por el equipo.
 - Limitaciones de presupuesto, proveedores cloud o herramientas existentes.
 - Estado actual de pipelines, scripts y configuraciones infraestructurales.
+- Dominios y variables de entorno para backend, frontend y backoffice, incluyendo CORS y secretos para Dokploy.
 
 ## Outputs esperados
 - Manifiestos IaC, scripts de automatización y pipelines actualizados.
 - Documentación sobre procedimientos de despliegue y rollback.
 - Recomendaciones sobre monitoreo, alertas y manejo de secretos.
+- Plantillas de compose y pipelines listos para reutilizar en Dokploy con los tres servicios.
 
 ## Límites y restricciones
 - No toma decisiones financieras ni de contratación de proveedores por sí solo.
@@ -35,6 +39,7 @@
 - Infraestructura reproducible, versionada y validada mediante pruebas automáticas.
 - Pipelines con etapas claras de validación, pruebas y despliegue seguro.
 - Documentación suficiente para que otros agentes ejecuten los procesos.
+- Verificación de que los subdominios respondan con certificados y healthchecks configurados.
 
 ## Ejemplos de tareas típicas
 - Crear una plantilla Terraform para un nuevo servicio.

--- a/agents/github_agent.md
+++ b/agents/github_agent.md
@@ -10,6 +10,7 @@
 
 ## Propósito
 - Gestionar issues, pull requests, labels y automatizaciones vinculadas al flujo de trabajo de GitHub del proyecto.
+- Reflejar en la clasificación los ámbitos del stack: backend (API), frontend (SPA), backoffice y la infraestructura de compose/Dokploy.
 
 ## Cuándo debe activarse
 - Al crear, actualizar o cerrar issues y pull requests que requieran clasificación y seguimiento formal.
@@ -24,6 +25,7 @@
 ## Outputs esperados
 - Issues y pull requests con labels consistentes según la guía centralizada.
 - Creación automática de labels faltantes alineadas con [`docs/GITHUB_LABELS.md`](../docs/GITHUB_LABELS.md).
+- Backlog de migración cargado en GitHub usando los títulos/cuerpos definidos en [`docs/migration_issues.md`](../docs/migration_issues.md).
 - Registro (comentarios o notas internas) de las acciones realizadas: etiquetas aplicadas, creaciones nuevas y cualquier incidencia detectada.
 
 ## Lógica de labels integrada
@@ -50,6 +52,8 @@
 
 ## Checklist operativo
 - [ ] Confirmar lectura actualizada de [`docs/GITHUB_LABELS.md`](../docs/GITHUB_LABELS.md).
+- [ ] Crear labels faltantes ejecutando el script documentado en la guía de labels (requiere GitHub CLI configurado).
+- [ ] Registrar los issues del backlog de migración descritos en [`docs/migration_issues.md`](../docs/migration_issues.md) aplicando las combinaciones de labels sugeridas.
 - [ ] Validar y sincronizar el catálogo de labels con GitHub antes de etiquetar.
 - [ ] Notificar al equipo cuando se creen nuevas labels o cambien colores/descripciones.
 - [ ] Mantener historial de acciones para auditoría posterior.

--- a/agents/integrador.md
+++ b/agents/integrador.md
@@ -10,21 +10,25 @@
 
 ## Propósito
 - Coordinar la incorporación ordenada de cambios en ramas principales y asegurar despliegues controlados.
+- Orquestar el compose unificado (backend, frontend y backoffice) y sus subdominios en Dokploy durante las ventanas de release.
 
 ## Responsabilidades
 - Revisar que generadores, auditores y testers hayan cumplido sus entregables.
 - Gestionar fusiones de ramas, resolución de conflictos y versiones etiquetadas.
 - Planificar ventanas de despliegue y comunicar estado al equipo.
+- Mantener los dominios, certificados y healthchecks coherentes en los entornos orquestados por Dokploy.
 
 ## Inputs esperados
 - Pull requests listas para integrar y reportes de auditoría y testing.
 - Checklist de criterios de aceptación y dependencias documentadas en `/docs`.
 - Historial de cambios y notas de versiones anteriores.
+- Variables de entorno, dominios y configuración del compose listos para el ciclo de despliegue.
 
 ## Outputs esperados
 - Planes de integración y despliegue con pasos claros.
 - Confirmación de merges completados y tags generados.
 - Resúmenes post-despliegue con incidencias y acciones de seguimiento.
+- Validación documentada de que los tres subdominios están operativos tras el despliegue.
 
 ## Límites y restricciones
 - No desarrolla funcionalidades nuevas ni modifica código sin coordinación previa.

--- a/agents/tester_backend.md
+++ b/agents/tester_backend.md
@@ -10,21 +10,25 @@
 
 ## Propósito
 - Validar la robustez, seguridad y rendimiento de los servicios backend antes y después de su integración.
+- Confirmar que la API desplegada en el subdominio backend responde correctamente a frontend y backoffice dentro del compose.
 
 ## Responsabilidades
 - Diseñar y ejecutar pruebas unitarias, de integración y contract testing sobre APIs y servicios.
 - Analizar resultados de pruebas de carga o resiliencia cuando aplique.
 - Comunicar hallazgos y colaborar en la priorización de fixes.
+- Validar CORS, JWT y healthchecks en el compose unificado y en despliegues de Dokploy.
 
 ## Inputs esperados
 - Endpoints nuevos o modificados junto con su documentación.
 - Datos de prueba, configuraciones de entornos y scripts asociados.
 - Criterios de aceptación y políticas de calidad definidas en `/docs`.
+- URLs de los subdominios y variables de entorno que impacten autenticación y CORS.
 
 ## Outputs esperados
 - Suites de pruebas automatizadas con cobertura de escenarios críticos.
 - Reportes de ejecución con métricas, logs y recomendaciones.
 - Evidencia de regresiones detectadas o confirmación de estabilidad.
+- Checklist de endpoints clave verificando interacciones con frontend y backoffice.
 
 ## Límites y restricciones
 - No introduce cambios funcionales en el código.
@@ -35,6 +39,7 @@
 - Pruebas reproducibles que cubran errores comunes y escenarios límite.
 - Reportes claros con pasos de reproducción y severidad de incidencias.
 - Automatizaciones integradas en pipelines con resultados trazables.
+- Validación de que los subdominios del compose superan healthchecks y que las políticas de CORS/JWT están activas.
 
 ## Ejemplos de tareas típicas
 - Crear pruebas de contrato para una API REST.

--- a/agents/tester_frontend.md
+++ b/agents/tester_frontend.md
@@ -10,21 +10,25 @@
 
 ## Propósito
 - Diseñar y ejecutar estrategias de prueba para validar la experiencia de usuario y la estabilidad de la capa visual.
+- Confirmar que el SPA en el subdominio frontend (y las vistas del backoffice cuando apliquen) funcionan contra la API del backend con CORS/JWT activos.
 
 ## Responsabilidades
 - Elaborar pruebas unitarias, de integración y end-to-end orientadas a componentes y flujos de interfaz.
 - Reportar incidencias y anomalías detectadas durante la ejecución de pruebas.
 - Colaborar con generadores y auditores para priorizar correcciones.
+- Validar rutas, autenticación y consumo de API vía subdominios definidos en el compose/Dokploy.
 
 ## Inputs esperados
 - Funcionalidades implementadas o diffs que afecten la capa de presentación.
 - Casos de uso y criterios de aceptación definidos en `/docs`.
 - Herramientas o scripts de testing existentes en el repositorio.
+- URLs de frontend y backoffice, claves JWT y configuración de CORS para pruebas end-to-end.
 
 ## Outputs esperados
 - Suites de pruebas automatizadas o guías de pruebas manuales.
 - Informes de resultados con pasos de reproducción y severidad.
 - Recomendaciones para mejorar la cobertura y resiliencia del frontend.
+- Evidencia de integración correcta con el backend (smoke/E2E) usando los subdominios configurados.
 
 ## Límites y restricciones
 - No modifica la lógica de negocio ni integra cambios en ramas principales.
@@ -35,6 +39,7 @@
 - Cobertura suficiente de casos críticos y de regresión.
 - Documentación clara de fallos y escenarios de prueba.
 - Automatizaciones confiables y repetibles dentro de la pipeline.
+- Validación de que la autenticación y las llamadas API respetan CORS y dominios definidos.
 
 ## Ejemplos de tareas típicas
 - Crear pruebas end-to-end para un flujo de compra.

--- a/docs/AGENTS_OVERVIEW.md
+++ b/docs/AGENTS_OVERVIEW.md
@@ -3,22 +3,37 @@
 ## Introducción
 - Los subagentes son especializaciones de Codex orientadas a cubrir distintas etapas del ciclo de desarrollo.
 - Esta vista permite entender rápidamente el rol de cada subagente y localizar su definición detallada en `/agents`.
+- El sistema replica el modelo operativo del repo de referencia (`CodexTest`), ajustado al stack actual: backend Django REST + PostgreSQL, frontend SPA en React/Vite, backoffice en React Admin y un `docker-compose` unificado con subdominios para backend, frontend y backoffice desplegado en Dokploy.
 
 ## Lista de subagentes
 
-| Identificador         | Tipo        | Propósito breve                                                | Fichero de definición         |
-|-----------------------|------------|----------------------------------------------------------------|-------------------------------|
-| generador_frontend    | generador  | Produce componentes y experiencias de interfaz alineadas al diseño. | /agents/generador_frontend.md |
-| generador_backend     | generador  | Implementa servicios, APIs y lógica de negocio escalable.      | /agents/generador_backend.md  |
-| generador_infra       | generador  | Automatiza infraestructura, pipelines y despliegues seguros.   | /agents/generador_infra.md    |
-| auditor_frontend      | auditor    | Revisa calidad y accesibilidad de los cambios de frontend.      | /agents/auditor_frontend.md   |
-| auditor_backend       | auditor    | Valida consistencia, seguridad y arquitectura del backend.      | /agents/auditor_backend.md    |
-| tester_frontend       | tester     | Diseña y ejecuta pruebas para la capa visual.                   | /agents/tester_frontend.md    |
-| tester_backend        | tester     | Verifica estabilidad y rendimiento de servicios backend.        | /agents/tester_backend.md     |
-| integrador            | integrador | Coordina merges y despliegues orquestando al resto de subagentes. | /agents/integrador.md         |
+| Identificador         | Tipo        | Propósito breve                                                | Fichero de definición       |
+|-----------------------|-------------|----------------------------------------------------------------|-----------------------------|
+| generador_frontend    | generador   | Produce componentes y experiencias de interfaz alineadas al diseño. | /agents/generador_frontend.md |
+| generador_backend     | generador   | Implementa servicios, APIs y lógica de negocio escalable.      | /agents/generador_backend.md  |
+| generador_infra       | generador   | Automatiza infraestructura, pipelines y despliegues seguros.   | /agents/generador_infra.md    |
+| auditor_frontend      | auditor     | Revisa calidad y accesibilidad de los cambios de frontend.     | /agents/auditor_frontend.md   |
+| auditor_backend       | auditor     | Valida consistencia, seguridad y arquitectura del backend.     | /agents/auditor_backend.md    |
+| tester_frontend       | tester      | Diseña y ejecuta pruebas para la capa visual.                  | /agents/tester_frontend.md    |
+| tester_backend        | tester      | Verifica estabilidad y rendimiento de servicios backend.       | /agents/tester_backend.md     |
+| integrador            | integrador  | Coordina merges y despliegues orquestando al resto de subagentes. | /agents/integrador.md         |
+| github_agent          | coordinador operativo | Administra issues/PRs, aplica labels y sincroniza el repositorio con las guías. | /agents/github_agent.md |
 
 ## Flujo operativo recomendado
 1. Un subagente generador (frontend, backend o infraestructura) crea o modifica el entregable solicitado.
 2. Un subagente auditor revisa los cambios para asegurar calidad, seguridad y alineación arquitectónica.
 3. Un subagente tester valida el comportamiento mediante pruebas automatizadas y manuales según corresponda.
 4. El subagente integrador coordina la integración en ramas principales y planifica despliegues controlados.
+5. El gestor de GitHub mantiene issues/PRs alineados con las guías y sincroniza etiquetas, milestones y documentación.
+
+## Plantilla de prompts (heredada de CodexTest y adaptada)
+- **Contexto**: módulo (backend/front/backoffice/infra), subdominio involucrado y dependencia con el `docker-compose` unificado.
+- **Tarea**: qué se espera (crear endpoint, ajustar CORS para subdominio, actualizar pipeline de Dokploy, etc.).
+- **Entradas**: enlaces a `/docs`, contratos API, maquetas, variables de entorno relevantes.
+- **Salidas**: código, migraciones, scripts de despliegue, pruebas y notas de riesgo.
+- **Validación**: checks que debe ejecutar el auditor/tester antes de integrar.
+
+## Cobertura del stack
+- **Backend (Django REST + PostgreSQL)**: subagentes backend se alinean a contratos versionados y autenticación JWT.
+- **Frontend (React + Vite)** y **Backoffice (React Admin)**: subagentes frontend/backoffice consideran rutas por subdominio y CORS cruzado con el backend.
+- **Infraestructura (Docker Compose + Dokploy)**: subagentes infra y el integrador mantienen el compose único con los tres servicios, certificados y healthchecks.

--- a/docs/GITHUB_LABELS.md
+++ b/docs/GITHUB_LABELS.md
@@ -50,8 +50,52 @@ Las labels de GitHub nos permiten clasificar issues y pull requests para prioriz
 - Bug crítico en backend que bloquea:
   - `type/bug`, `area/backend`, `priority/P0-blocker`, `status/blocked`, `size/S`
   - Sirve para destacar errores severos en la API que impiden avanzar hasta su resolución.
-- Tarea de documentación:
+  - Tarea de documentación:
   - `type/docs`, `area/docs`, `priority/P2-medium`, `size/XS`
   - Permite planificar actualizaciones de documentación sin urgencia inmediata.
 
 Estas combinaciones son orientativas; ajusta las labels según el contexto real del trabajo.
+
+## Cómo crear las labels en un repositorio nuevo
+> Usa `gh` (GitHub CLI) autenticado con un token que tenga permisos sobre el repo. Ejecuta el siguiente script desde la raíz del proyecto para crear todas las labels definidas en esta guía.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'JSON' | gh api --method PUT -H "Accept: application/vnd.github+json" \
+  /repos/:owner/:repo/labels --input -
+[
+  {"name":"type/feature","color":"1D76DB","description":"Nueva funcionalidad o mejora visible para usuarios."},
+  {"name":"type/bug","color":"D73A4A","description":"Corrección de un error que afecta al comportamiento esperado."},
+  {"name":"type/chore","color":"FBCA04","description":"Tarea de mantenimiento, limpieza o actualización menor."},
+  {"name":"type/refactor","color":"C5DEF5","description":"Refactorización interna sin cambios funcionales."},
+  {"name":"type/docs","color":"5319E7","description":"Trabajo relacionado con documentación."},
+  {"name":"type/spike","color":"0E8A16","description":"Investigación, prototipo o validación rápida de ideas."},
+  {"name":"area/frontend","color":"F9D0C4","description":"Código de interfaz de usuario, componentes y estilos."},
+  {"name":"area/backend","color":"FEE39F","description":"APIs, lógica de negocio, integraciones y base de datos."},
+  {"name":"area/infra","color":"C2E0C6","description":"Infraestructura, IaC, CI/CD y despliegues."},
+  {"name":"area/devops","color":"C5F1FF","description":"Pipelines, observabilidad y tooling operativo."},
+  {"name":"area/docs","color":"E4E669","description":"Documentación funcional o técnica del proyecto."},
+  {"name":"priority/P0-blocker","color":"B60205","description":"Bloqueante: requiere atención inmediata."},
+  {"name":"priority/P1-high","color":"D93F0B","description":"Alta prioridad: debe atenderse pronto."},
+  {"name":"priority/P2-medium","color":"FBCA04","description":"Prioridad media: importante pero no urgente."},
+  {"name":"priority/P3-low","color":"0E8A16","description":"Prioridad baja: se puede planificar más adelante."},
+  {"name":"status/ready","color":"0E8A16","description":"Listo para que alguien lo tome."},
+  {"name":"status/in-progress","color":"1D76DB","description":"Trabajo actualmente en curso."},
+  {"name":"status/blocked","color":"D73A4A","description":"Bloqueado por dependencias externas o problemas pendientes."},
+  {"name":"status/needs-review","color":"5319E7","description":"Requiere revisión técnica o funcional."},
+  {"name":"status/needs-info","color":"FEE39F","description":"Falta información o aclaraciones para avanzar."},
+  {"name":"status/done","color":"7057FF","description":"Trabajo completado y aprobado."},
+  {"name":"size/XS","color":"BFE5BF","description":"Esfuerzo mínimo, menos de media jornada."},
+  {"name":"size/S","color":"99D1B9","description":"Esfuerzo pequeño, hasta una jornada."},
+  {"name":"size/M","color":"6FBA82","description":"Esfuerzo medio, entre una y dos jornadas."},
+  {"name":"size/L","color":"3E8E41","description":"Esfuerzo grande, varios días de trabajo."},
+  {"name":"size/XL","color":"196127","description":"Esfuerzo muy grande, requiere planificación dedicada."}
+]
+JSON
+```
+
+### Aplicación rápida de labels sugeridas
+- Para issues del backlog de migración, aplica al menos una label `type/*`, una `area/*`, una `priority/*` y añade `size/*` según estimación.
+- Usa `status/ready` para issues listos para ser tomados y `status/in-progress` al asignar a alguien.

--- a/docs/migration_issues.md
+++ b/docs/migration_issues.md
@@ -1,0 +1,87 @@
+# Backlog inicial de migración (heredado de proceso de publicación del proyecto origen)
+
+Este backlog replica el proceso de publicación usado en el repositorio de referencia y lo adapta al stack unificado (backend, frontend y backoffice en un mismo `docker-compose` con subdominios y despliegue en Dokploy). Cada ítem está listo para crearse como issue en GitHub, con labels sugeridas y criterios de aceptación.
+
+## Cómo usar este backlog
+1. Verifica que las labels existan (usa la guía de [`docs/GITHUB_LABELS.md`](./GITHUB_LABELS.md) para crearlas si faltan).
+2. Crea cada issue con el título y el cuerpo indicados; aplica las labels sugeridas.
+3. Ajusta tamaños (`size/*`) y estados (`status/*`) según el contexto real.
+
+## Issues propuestos
+
+### 1) Compose unificado con subdominios
+- **Título**: "Infra: Compose unificado backend/frontend/backoffice con subdominios"
+- **Labels sugeridas**: `type/feature`, `area/infra`, `priority/P1-high`, `size/M`, `status/ready`
+- **Cuerpo sugerido**:
+  - **Objetivo**: Definir un `docker-compose` único que ejecute backend, frontend y backoffice con sus subdominios (ej. `api.example.com`, `app.example.com`, `admin.example.com`) y certificados listos para Dokploy.
+  - **Tareas**:
+    - Contenerización de backend con variables JWT, base de datos y media persistente.
+    - Contenerización de frontend y backoffice apuntando al backend por subdominio y con CORS alineado.
+    - Definir volúmenes, redes y healthchecks.
+  - **Criterios de aceptación**:
+    - Compose validado localmente (arranca los tres servicios).
+    - Subdominios documentados en `/docs` y variables mapeadas.
+    - Servicios listos para Dokploy (puertos, certificados y dependencia entre servicios).
+
+### 2) Variables de entorno extendidas (incluyendo backoffice)
+- **Título**: "Docs: Variables de entorno para backend/frontend/backoffice con subdominios"
+- **Labels sugeridas**: `type/docs`, `area/docs`, `priority/P1-high`, `size/S`, `status/ready`
+- **Cuerpo sugerido**:
+  - **Objetivo**: Completar la guía de `.env` para los tres servicios, incluyendo URLs por subdominio y ajustes de CORS.
+  - **Tareas**:
+    - Añadir secciones específicas de backoffice (JWT, API base, orígenes permitidos).
+    - Ejemplos de valores para dev/staging/prod usando los subdominios del compose.
+    - Sincronización de secrets para GitHub Actions y Dokploy.
+  - **Criterios de aceptación**:
+    - Documento `/docs/environment.md` actualizado con tablas de variables y ejemplos.
+    - Referencia cruzada desde README y/o notas de despliegue.
+
+### 3) Pipeline de publicación en Dokploy
+- **Título**: "Infra: Pipeline de despliegue en Dokploy para stack unificado"
+- **Labels sugeridas**: `type/feature`, `area/infra`, `priority/P1-high`, `size/M`, `status/ready`
+- **Cuerpo sugerido**:
+  - **Objetivo**: Replicar el proceso de publicación del proyecto origen en Dokploy usando el compose unificado.
+  - **Tareas**:
+    - Definir secretos y variables necesarios en Dokploy (JWT, DB, hosts, certificados).
+    - Configurar pasos de build/pull y arranque de servicios, incluyendo healthchecks.
+    - Documentar rollback y validaciones post-deploy.
+  - **Criterios de aceptación**:
+    - Documentación de pipeline en `/docs` con comandos y orden de ejecución.
+    - Checklist de verificación tras el despliegue (endpoints y front/backoffice accesibles por subdominio).
+
+### 4) CI básica para el stack
+- **Título**: "DevOps: CI mínima para backend, frontend y backoffice"
+- **Labels sugeridas**: `type/chore`, `area/devops`, `priority/P2-medium`, `size/M`, `status/ready`
+- **Cuerpo sugerido**:
+  - **Objetivo**: Configurar workflows que ejecuten lint/tests para las tres apps y builden imágenes cuando proceda.
+  - **Tareas**:
+    - Pipeline de backend (lint, tests, migrations check, build opcional).
+    - Pipeline de frontend y backoffice (lint/build) con variables de API base por entorno.
+    - Publicación de artefactos o imágenes en el registro usado por Dokploy.
+  - **Criterios de aceptación**:
+    - Workflows en `.github/workflows` validados en CI.
+    - Matriz de estados visible en PRs.
+
+### 5) Sistema de subagentes alineado al stack
+- **Título**: "Docs: Ajustar sistema de subagentes al compose unificado"
+- **Labels sugeridas**: `type/docs`, `area/docs`, `priority/P2-medium`, `size/S`, `status/ready`
+- **Cuerpo sugerido**:
+  - **Objetivo**: Confirmar que los perfiles de subagentes cubren casos del compose (subdominios, CORS, Dokploy) y agregar ejemplos de prompts si faltan.
+  - **Tareas**:
+    - Revisar `/agents` y `/docs/AGENTS_OVERVIEW.md` para reflejar el flujo de publicación.
+    - Añadir prompts de ejemplo por dominio (backend, frontend, backoffice, infra).
+    - Registrar dependencias entre subagentes (generador → auditor → tester → integrador).
+  - **Criterios de aceptación**:
+    - Documentos actualizados y enlazados desde el README o índice.
+
+### 6) Auditoría de CORS y subdominios
+- **Título**: "Backend: Auditoría de CORS/JWT para subdominios del stack"
+- **Labels sugeridas**: `type/spike`, `area/backend`, `priority/P1-high`, `size/S`, `status/ready`
+- **Cuerpo sugerido**:
+  - **Objetivo**: Validar requisitos de CORS, JWT y seguridad para servir a frontend y backoffice desde subdominios separados.
+  - **Tareas**:
+    - Revisar configuración de CORS/CSRF en backend.
+    - Proponer ajustes de claims/expiraciones JWT si aplica a backoffice.
+    - Documentar riesgos y plan de mitigación.
+  - **Criterios de aceptación**:
+    - Informe breve adjunto al issue con recomendaciones aplicables al compose.


### PR DESCRIPTION
## Summary
- add a ready-to-use migration backlog document with suggested issue titles, bodies, and labels
- document a GitHub CLI script to create the standardized label set and reference it in the GitHub agent checklist
- surface the migration backlog and label guide from the README for quick access

## Testing
- not run (documentation updates only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691adc4ab2108327ab32d45932046e1f)