### PR TITLE
[Frontend] Validación robusta de VITE_API_BASE_URL al arranque

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getValidBaseUrl } from "@/lib/api";
+
+describe("getValidBaseUrl", () => {
+  const fallbackUrl = "http://localhost:8000/api/v1";
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("should return fallback URL and log error when URL is undefined", () => {
+    const result = getValidBaseUrl(undefined);
+    expect(result).toBe(fallbackUrl);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "VITE_API_BASE_URL is not defined. Falling back to default: " + fallbackUrl
+    );
+  });
+
+  it("should return fallback URL and log error when URL is empty", () => {
+    const result = getValidBaseUrl("");
+    expect(result).toBe(fallbackUrl);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "VITE_API_BASE_URL is not defined. Falling back to default: " + fallbackUrl
+    );
+  });
+
+  it("should return fallback URL and log error when URL is invalid", () => {
+    const invalidUrl = "not-a-valid-url";
+    const result = getValidBaseUrl(invalidUrl);
+    expect(result).toBe(fallbackUrl);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      `VITE_API_BASE_URL is invalid: "${invalidUrl}". Falling back to default: ` + fallbackUrl
+    );
+  });
+
+  it("should return normalized URL when URL is valid and doesn't end with /api", () => {
+    const validUrl = "https://example.com/custom-api";
+    const result = getValidBaseUrl(validUrl);
+    expect(result).toBe(validUrl);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("should return normalized URL with /v1 when URL is valid and ends with /api", () => {
+    const validUrl = "https://example.com/api";
+    const result = getValidBaseUrl(validUrl);
+    expect(result).toBe("https://example.com/api/v1");
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("should strip trailing slashes", () => {
+    const validUrl = "https://example.com/api/";
+    const result = getValidBaseUrl(validUrl);
+    expect(result).toBe("https://example.com/api/v1");
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -32,9 +32,30 @@ function normalizeApiBaseUrl(value: string): string {
   return trimmed;
 }
 
-export const API_BASE_URL = normalizeApiBaseUrl(
-  rawBaseUrl || "http://localhost:8000/api/v1",
-);
+export function getValidBaseUrl(url: string | undefined): string {
+  const fallbackUrl = "http://localhost:8000/api/v1";
+
+  if (!url) {
+    // eslint-disable-next-line no-console
+    console.error(
+      "VITE_API_BASE_URL is not defined. Falling back to default: " + fallbackUrl
+    );
+    return fallbackUrl;
+  }
+
+  try {
+    new URL(url);
+    return normalizeApiBaseUrl(url);
+  } catch {
+    // eslint-disable-next-line no-console
+    console.error(
+      `VITE_API_BASE_URL is invalid: "${url}". Falling back to default: ` + fallbackUrl
+    );
+    return fallbackUrl;
+  }
+}
+
+export const API_BASE_URL = getValidBaseUrl(rawBaseUrl);
 
 function getUrl(path: string): string {
   return `${API_BASE_URL}${path.startsWith("/") ? "" : "/"}${path}`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4392,7 +4392,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-dirs@0.1.1:
     resolution: {integrity: sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==}
@@ -6495,6 +6495,7 @@ packages:
   tar@7.5.6:
     resolution: {integrity: sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp-dir@2.0.0:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
@@ -11010,9 +11011,9 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-expo: 1.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.2(jiti@2.6.1))
       globals: 16.5.0
@@ -11030,7 +11031,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11041,18 +11042,18 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -11065,7 +11066,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11076,7 +11077,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
Resuelve #77: Validación robusta de `VITE_API_BASE_URL` al arranque.

*   **Validación de `VITE_API_BASE_URL`:** Se introdujo la función `getValidBaseUrl` en `frontend/src/lib/api.ts` para verificar si la variable de entorno se define y si el formato de la URL es correcto usando `new URL()`.
*   **Manejo de Errores Controlado:** Si el formato de la URL es inválido o no existe, se registra el error a través de `console.error` para una rápida identificación del fallo sin llegar a romper la aplicación de manera silenciosa.
*   **Fallback Configurado:** Si falla, la aplicación asigna por defecto el fallback `"http://localhost:8000/api/v1"`.
*   **Test de Unidad Adicionado:** Se creó `frontend/src/lib/api.test.ts` para asegurar que el sistema no se rompa bajo casos extremos (vacío, inválido, no configurado, bien definido) y simular el fallback, usando mockeo para las alertas.

Se cumple todos los criterios definidos, respetando la estructura con `@/` y ejecutando comprobaciones correctas con los tests (`npm test --prefix frontend -- --run`) y check de tipo (`npm run type-check --prefix frontend`).

---
*PR created automatically by Jules for task [5570515263618274869](https://jules.google.com/task/5570515263618274869) started by @cdryampi*