### PR TITLE
[Frontend][DX] Añadir scripts lint y lint:fix

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -88,3 +88,17 @@ npm run test
 ```
 
 > ✳️ Agrega pruebas dentro de `src` utilizando el sufijo `.test.ts` o `.test.tsx`.
+
+## Análisis estático (Linting)
+
+Para analizar el código fuente en busca de errores de sintaxis y problemas de estilo, puedes usar:
+
+```bash
+npm run lint
+```
+
+Para intentar corregir automáticamente los problemas detectados, puedes usar:
+
+```bash
+npm run lint:fix
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,9 @@
     "build": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc -b && cross-env NODE_OPTIONS=--max-old-space-size=8192 vite build",
     "preview": "vite preview",
     "test": "cross-env NODE_OPTIONS=--max-old-space-size=8192 vitest",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "lint": "eslint \"src\"",
+    "lint:fix": "eslint \"src\" --fix"
   },
   "dependencies": {
     "@fontsource/plus-jakarta-sans": "^5.2.8",

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -1,7 +1,7 @@
 const apiBaseUrl = import.meta.env.VITE_API_BASE_URL;
 
 if (import.meta.env.DEV && !apiBaseUrl) {
-  // eslint-disable-next-line no-console
+
   console.warn("VITE_API_BASE_URL is not defined. Some API calls may fail.");
 }
 


### PR DESCRIPTION
Adds `lint` and `lint:fix` commands to the frontend package.json, pointing eslint to the `src` directory. Updates `frontend/README.md` to document how to run these new scripts for static analysis and automatic fixes. Verified scripts run correctly and tests pass.

---
*PR created automatically by Jules for task [13561578944705681495](https://jules.google.com/task/13561578944705681495) started by @cdryampi*