### PR TITLE
⚡ Optimize weather forecast N+1 query in EventSerializer

### DIFF
--- a/backend/events/serializers.py
+++ b/backend/events/serializers.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from django.conf import settings
+from django.utils import timezone
 from rest_framework import serializers
 from parler_rest.serializers import TranslatableModelSerializer, TranslatedFieldsField
 
 from core.models import Category, Tag
+from site_settings.models_weather import MunicipalityWeather
 from core.serializers import TagSerializer
 from media_files.models import DocumentFile, ImageFile
 from media_files.serializers import DocumentFileSerializer, ImageFileSerializer
@@ -141,8 +143,6 @@ class EventSerializer(TranslatableModelSerializer):
         - ongoing: has a session currently happening.
         - finished: all sessions are in the past.
         """
-        from django.utils import timezone
-
         now = timezone.now()
         dates = obj.dates.all()
 
@@ -169,10 +169,10 @@ class EventSerializer(TranslatableModelSerializer):
         if not obj.is_outdoor or not obj.start_at:
             return None
 
-        from site_settings.models_weather import MunicipalityWeather
-        from django.utils import timezone
+        if not hasattr(self, "_cached_weather"):
+            self._cached_weather = MunicipalityWeather.objects.order_by("-updated_at").first()
 
-        weather = MunicipalityWeather.objects.order_by("-updated_at").first()
+        weather = self._cached_weather
         if not weather:
             return None
 


### PR DESCRIPTION
### 💡 What:
Optimized the `get_weather_forecast` method in `EventSerializer` by caching the latest `MunicipalityWeather` object on the serializer instance.

### 🎯 Why:
Previously, the method performed a database query for the latest weather data for every event being serialized. In list views, this resulted in N queries for the same weather data (N+1 problem).

### 📊 Measured Improvement:
While local environment limitations prevented running a full automated benchmark, the optimization theoretically reduces the number of queries for weather data from O(N) to O(1) per list serialization. In DRF, the same serializer instance is reused when `many=True` is used, making instance-level caching effective for this purpose.

The changes also included moving imports to the top level to follow Python best practices and avoid repeated import overhead.

---
*PR created automatically by Jules for task [127079449325922529](https://jules.google.com/task/127079449325922529) started by @cdryampi*