### PR TITLE
Add unified `seed_all` command with deterministic seeding, dry-run and selective steps; update seeds README and tests

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -77,43 +77,39 @@ python manage.py migrate
 python manage.py migrate
 ```
 
-## Seeds obligatorios (usuarios, eventos, lugares)
+## Seeds (flujo estandarizado)
 
-Ejecuta estos comandos tras migrar para evitar errores en admin/API:
-
-```bash
-# Windows
-python manage.py seed_users
-python manage.py seed_events_category
-python manage.py seed_places_category
-python manage.py seed_places
-
-# Linux/Mac
-python manage.py seed_users
-python manage.py seed_events_category
-python manage.py seed_places_category
-python manage.py seed_places
-```
-
-### Deep Seed (Nuclear Cleanup & Sync)
-
-Para resolver inconsistencias y realizar un reset completo y limpio con datos estéticos sincronizados entre Backend y Frontend (incluyendo imágenes AI premium e iconos de Lucide):
+Comando recomendado (local o CI):
 
 ```bash
-# Limpiar TODO (Categorías, Places, Events, Media) y volver a sembrar con fechas de HOY
-python nuclear_cleanup.py
-
-# Limpiar y sembrar con eventos desplazados 10 días al futuro (útil para pruebas de agenda)
-python nuclear_cleanup.py --days 10
-
-# Solo limpiar (sin volver a sembrar)
-python nuclear_cleanup.py --no-seed
+python manage.py seed_all
 ```
 
-`nuclear_cleanup.py` orquesta la eliminación nuclear de registros protegidos y lanza los comandos de seed en el orden correcto (`places_category`, `events_category`, `tags`, `places`, `events`).
+Opciones estandar:
 
-`seed_places` usa las imágenes incluidas en `seed/images/` y crea datos de ejemplo con media y traducciones.
-Los datos de seeds están separados en JSON por app (p.ej. `places/seed/places.json`, `events/seed/events.json`, `core/seed/tags.json`).
+```bash
+# reset completo + migraciones + seed
+python manage.py seed_all --reset --noinput
+
+# ejecucion reproducible (determinista para seeds con aleatoriedad)
+python manage.py seed_all --seed 42
+
+# ejecutar solo dominios concretos
+python manage.py seed_all --only users,events
+
+# simular sin escribir en base de datos
+python manage.py seed_all --dry-run --only users,events
+```
+
+Compatibilidad legacy:
+
+- `--hard-reset` se mantiene como alias deprecado de `--reset`.
+- `nuclear_cleanup.py` se mantiene por compatibilidad, pero el flujo recomendado es `seed_all`.
+
+Notas de orden/dependencias:
+
+- `seed_all` orquesta el orden de comandos para evitar dependencias frágiles.
+- Los datos de seeds están separados por app (p.ej. `places/seed/places.json`, `events/seed/events.json`, `core/seed/tags.json`).
 
 Usuarios creados:
 

--- a/backend/core/management/commands/seed_all.py
+++ b/backend/core/management/commands/seed_all.py
@@ -1,61 +1,126 @@
 from __future__ import annotations
 
+import os
+
 from django.core.management import call_command
 from django.core.management.base import BaseCommand, CommandError
 
+from core.seed_utils import GLOBAL_SEED_ENV_VAR
+
+
+SEED_PIPELINE: list[tuple[str, str, str]] = [
+    ("users", "seed_users", "Seeding users..."),
+    ("media_files", "seed_media_files", "Seeding media files..."),
+    ("static_pages", "seed_static_pages", "Seeding static pages..."),
+    ("site_settings", "seed_site_settings", "Seeding site settings..."),
+    ("social", "seed_social", "Seeding social content..."),
+    ("tags", "seed_tags", "Seeding tags..."),
+    ("places_category", "seed_places_category", "Seeding places categories..."),
+    ("places", "seed_places", "Seeding places..."),
+    ("events_category", "seed_events_category", "Seeding events category..."),
+    ("events", "seed_events", "Seeding events..."),
+    ("gamification", "seed_gamification", "Seeding gamification..."),
+]
+
 
 class Command(BaseCommand):
-    help = (
-        "Seed the database with demo data for all apps (optionally hard reset first)."
-    )
+    help = "Seed database demo data using a reproducible and observable orchestration flow."
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--hard-reset",
+            "--reset",
             action="store_true",
             help="Flush DB and run migrations before seeding (DANGEROUS).",
         )
         parser.add_argument(
+            "--hard-reset",
+            action="store_true",
+            help="Deprecated alias of --reset.",
+        )
+        parser.add_argument(
             "--noinput",
             action="store_true",
-            help="Do not prompt for input (used with --hard-reset).",
+            help="Do not prompt for input (used with --reset).",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show planned operations but do not execute them.",
+        )
+        parser.add_argument(
+            "--seed",
+            type=int,
+            help="Deterministic seed used by commands that support randomness.",
+        )
+        parser.add_argument(
+            "--only",
+            type=str,
+            help="Comma-separated domains from seed_all pipeline (e.g. users,events).",
         )
 
     def handle(self, *args, **options):
-        hard_reset: bool = options["hard_reset"]
+        reset: bool = options["reset"] or options["hard_reset"]
+        hard_reset_alias: bool = options["hard_reset"]
         noinput: bool = options["noinput"]
+        dry_run: bool = options["dry_run"]
+        seed: int | None = options.get("seed")
 
-        if hard_reset:
+        if hard_reset_alias:
+            self.stdout.write(
+                self.style.WARNING("`--hard-reset` is deprecated. Use `--reset` instead.")
+            )
+
+        selected_steps = self._resolve_steps(options.get("only"))
+
+        if seed is not None:
+            os.environ[GLOBAL_SEED_ENV_VAR] = str(seed)
+            self.stdout.write(self.style.NOTICE(f"Using deterministic seed={seed}."))
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("Dry-run mode enabled. No writes will occur."))
+
+        if reset:
             self.stdout.write(
                 self.style.WARNING(
-                    "Hard reset requested: flushing database and re-applying migrations."
+                    "Reset requested: flushing database and re-applying migrations."
                 )
             )
-            call_command("flush", interactive=not noinput)
-            call_command("migrate", interactive=not noinput)
+            self._run_command("flush", dry_run=dry_run, interactive=not noinput)
+            self._run_command("migrate", dry_run=dry_run, interactive=not noinput)
 
-        seed_commands: list[tuple[str, str]] = [
-            ("seed_users", "Seeding users..."),
-            ("seed_media_files", "Seeding media files..."),
-            ("seed_static_pages", "Seeding static pages..."),
-            ("seed_site_settings", "Seeding site settings..."),
-            ("seed_social", "Seeding social content..."),
-            ("seed_tags", "Seeding tags..."),
-            ("seed_places_category", "Seeding places categories..."),
-            ("seed_places", "Seeding places..."),
-            ("seed_events_category", "Seeding events category..."),
-            ("seed_events", "Seeding events..."),
-            # Note: News are now scraped from external sources, no seed command
-            ("seed_gamification", "Seeding gamification..."),
-        ]
+        for domain, command_name, message in selected_steps:
+            self.stdout.write(self.style.MIGRATE_HEADING(f"[{domain}] {message}"))
+            self._run_command(command_name, dry_run=dry_run)
 
-        for command_name, message in seed_commands:
-            self.stdout.write(self.style.MIGRATE_HEADING(message))
-            try:
-                call_command(command_name)
-            except CommandError as exc:
-                raise CommandError(
-                    f"seed_all failed running `{command_name}`: {exc}"
-                ) from exc
+        if seed is not None:
+            os.environ.pop(GLOBAL_SEED_ENV_VAR, None)
 
         self.stdout.write(self.style.SUCCESS("Seed process completed."))
+
+    def _resolve_steps(self, only: str | None) -> list[tuple[str, str, str]]:
+        if not only:
+            return SEED_PIPELINE
+
+        requested = [item.strip() for item in only.split(",") if item.strip()]
+        if not requested:
+            return SEED_PIPELINE
+
+        available = {domain for domain, _, _ in SEED_PIPELINE}
+        invalid = sorted(set(requested) - available)
+        if invalid:
+            raise CommandError(
+                f"Unknown values in --only: {', '.join(invalid)}. "
+                f"Allowed: {', '.join(sorted(available))}"
+            )
+
+        requested_set = set(requested)
+        return [step for step in SEED_PIPELINE if step[0] in requested_set]
+
+    def _run_command(self, command_name: str, *, dry_run: bool, **kwargs):
+        if dry_run:
+            self.stdout.write(self.style.NOTICE(f"[dry-run] would run `{command_name}`"))
+            return
+        try:
+            call_command(command_name, **kwargs)
+        except CommandError as exc:
+            raise CommandError(f"seed_all failed running `{command_name}`: {exc}") from exc

--- a/backend/core/seed_utils.py
+++ b/backend/core/seed_utils.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+import random
+from dataclasses import dataclass
+from typing import Any
+
+
+GLOBAL_SEED_ENV_VAR = "GAUDEIX_SEED"
+
+
+@dataclass(frozen=True)
+class SeedContext:
+    seed: int | None
+    rng: random.Random
+    faker: Any
+
+
+def resolve_seed(explicit_seed: int | None) -> int | None:
+    if explicit_seed is not None:
+        return explicit_seed
+
+    env_value = os.getenv(GLOBAL_SEED_ENV_VAR)
+    if env_value is None or env_value == "":
+        return None
+
+    try:
+        return int(env_value)
+    except ValueError:
+        return None
+
+
+def build_seed_context(*, explicit_seed: int | None, faker_locale: str = "es_ES") -> SeedContext:
+    from faker import Faker
+
+    resolved_seed = resolve_seed(explicit_seed)
+    rng = random.Random()
+    faker = Faker(faker_locale)
+
+    if resolved_seed is not None:
+        rng.seed(resolved_seed)
+        faker.seed_instance(resolved_seed)
+
+    return SeedContext(seed=resolved_seed, rng=rng, faker=faker)

--- a/backend/events/management/commands/seed_future_events.py
+++ b/backend/events/management/commands/seed_future_events.py
@@ -1,7 +1,6 @@
 
 from __future__ import annotations
 
-import random
 import mimetypes
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -11,11 +10,11 @@ from django.core.files import File
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.utils import timezone
-from faker import Faker
 
-from core.models import Category, Tag
+from core.models import Category
 from events.models import Event
 from media_files.models import ImageFile
+from core.seed_utils import build_seed_context
 
 
 class Command(BaseCommand):
@@ -28,12 +27,30 @@ class Command(BaseCommand):
             default=100,
             help="Number of events to generate",
         )
+        parser.add_argument(
+            "--seed",
+            type=int,
+            help="Deterministic seed for random/Faker generation.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Simulate generation without writing to database.",
+        )
 
     def handle(self, *args, **options):
         count = options["count"]
+        dry_run = options.get("dry_run", False)
+        seed_context = build_seed_context(explicit_seed=options.get("seed"), faker_locale="es_ES")
+
         self.stdout.write(self.style.WARNING(f"Seeding {count} future events for Cabrera de Mar..."))
-        
-        fake = Faker('es_ES')
+        if seed_context.seed is not None:
+            self.stdout.write(self.style.NOTICE(f"Using deterministic seed={seed_context.seed}"))
+        if dry_run:
+            self.stdout.write(self.style.WARNING("Dry-run mode enabled. No writes will occur."))
+
+        fake = seed_context.faker
+        rng = seed_context.rng
         base_now = timezone.now()
         end_date = datetime(2026, 2, 28, 23, 59, 59, tzinfo=ZoneInfo("Europe/Madrid"))
         
@@ -61,6 +78,10 @@ class Command(BaseCommand):
             "Networking": "networking.png",
             "Playa": "beach.png",
         }
+
+        if dry_run:
+            self.stdout.write(self.style.NOTICE(f"[dry-run] would create approximately {count} future events."))
+            return
 
         # Root category
         root_category, _ = Category.objects.get_or_create(
@@ -223,7 +244,7 @@ class Command(BaseCommand):
             # Generate specified count of events
             for _ in range(count):
                 # Pick category
-                cat_name = random.choice(list(categories_map.keys()))
+                cat_name = rng.choice(list(categories_map.keys()))
                 
                 # Get or Create Category
                 category_slug = cat_name.lower().replace("á", "a").replace("í", "i").replace("ó", "o")
@@ -238,18 +259,18 @@ class Command(BaseCommand):
 
                 # Random date between now and end_date
                 time_diff = end_date - base_now
-                random_seconds = random.randint(0, int(time_diff.total_seconds()))
+                random_seconds = rng.randint(0, int(time_diff.total_seconds()))
                 start_at = base_now + timedelta(seconds=random_seconds)
-                end_at = start_at + timedelta(hours=random.randint(2, 6))
+                end_at = start_at + timedelta(hours=rng.randint(2, 6))
 
                 # Pick template and location
-                title = random.choice(event_templates[cat_name])
-                location_data = random.choice(cabrera_locations)
+                title = rng.choice(event_templates[cat_name])
+                location_data = rng.choice(cabrera_locations)
                 
                 summary = f"Únete a nosotros para el evento '{title}' en {location_data['name']}. Una actividad organizada por el Ayuntamiento de Cabrera de Mar para fomentar la cultura y la participación ciudadana."
                 description = f"El evento '{title}' es una de las actividades destacadas de la agenda municipal de Cabrera de Mar. Se llevará a cabo en {location_data['name']} ({location_data['address']}).\n\nEsperamos contar con vuestra presencia para disfrutar de una jornada dedicada a {cat_name.lower()}. No te pierdas esta oportunidad de conectar con la comunidad y disfrutar de lo mejor que nuestro municipio tiene para ofrecer."
                 
-                price = f"{random.randint(5, 25)} EUR" if random.choice([True, False, False]) else "Gratis"
+                price = f"{rng.randint(5, 25)} EUR" if rng.choice([True, False, False]) else "Gratis"
 
                 # Image
                 featured_media = images_cache.get(cat_name)
@@ -257,7 +278,7 @@ class Command(BaseCommand):
                 # Create Event
                 event = Event.objects.create(
                     title=title,
-                    slug=fake.slug() + str(random.randint(1000,9999)),
+                    slug=fake.slug() + str(rng.randint(1000,9999)),
                     summary=summary,
                     description=description,
                     start_at=start_at,

--- a/backend/gaudeix_backend/tests/test_seed_all.py
+++ b/backend/gaudeix_backend/tests/test_seed_all.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import os
+from unittest.mock import call, patch
+
 import pytest
 from django.core.management import call_command
+from django.core.management.base import CommandError
 
 from core.models import Category
 from site_settings.models import SiteSettings
@@ -33,3 +37,33 @@ def test_seed_all_hard_reset_is_idempotent(settings, tmp_path, transactional_db)
 
     assert not User.objects.filter(username="temp").exists()
     assert User.objects.count() >= 2
+
+
+def test_seed_all_only_runs_selected_domains():
+    with patch("core.management.commands.seed_all.call_command") as mock_call:
+        call_command("seed_all", "--only", "users,events", verbosity=0)
+
+    assert mock_call.call_args_list == [
+        call("seed_users"),
+        call("seed_events"),
+    ]
+
+
+def test_seed_all_dry_run_does_not_execute_subcommands():
+    with patch("core.management.commands.seed_all.call_command") as mock_call:
+        call_command("seed_all", "--dry-run", "--only", "users", verbosity=0)
+
+    mock_call.assert_not_called()
+
+
+def test_seed_all_rejects_unknown_only_value():
+    with pytest.raises(CommandError):
+        call_command("seed_all", "--only", "unknown", verbosity=0)
+
+
+def test_seed_all_seed_sets_and_cleans_env_var():
+    with patch("core.management.commands.seed_all.call_command") as mock_call:
+        assert os.getenv("GAUDEIX_SEED") is None
+        call_command("seed_all", "--seed", "123", "--only", "users", verbosity=0)
+        assert mock_call.call_args_list == [call("seed_users")]
+        assert os.getenv("GAUDEIX_SEED") is None


### PR DESCRIPTION
### Motivation

- Provide a single, observable orchestration for seeding demo data to avoid fragile ordering and multiple ad-hoc scripts.
- Allow reproducible/deterministic seeds and safer operations via `--dry-run` and selective execution to improve local and CI workflows.

### Description

- Added `core/management/commands/seed_all.py` implementing a sequenced pipeline (`SEED_PIPELINE`) and new CLI options `--reset` (with deprecated `--hard-reset` alias), `--noinput`, `--dry-run`, `--seed`, and `--only` to run selected domains, plus internal helpers `_resolve_steps` and `_run_command` for validation and dry-run behavior.
- Added `core/seed_utils.py` exposing `GLOBAL_SEED_ENV_VAR`, `resolve_seed`, and `build_seed_context` to centralize deterministic RNG and `Faker` initialization using the `GAUDEIX_SEED` env var.
- Updated `events/management/commands/seed_future_events.py` to consume the seed context via `build_seed_context`, switch from global `random` to a reproducible `rng`, and support `--seed` and `--dry-run` flags and clearer logging.
- Updated `backend/README.md` to document the new `seed_all` usage, examples for `--reset`, `--seed`, `--only`, `--dry-run`, and legacy compatibility notes keeping `nuclear_cleanup.py` and `--hard-reset` as deprecated aliases.
- Added tests in `gaudeix_backend/tests/test_seed_all.py` exercising the new behaviors for `--only`, `--dry-run`, `--seed`, and ensuring `--hard-reset` continues to work as an alias.

### Testing

- Ran the test module covering the new command: `pytest backend/gaudeix_backend/tests/test_seed_all.py`, which executed tests for basic seeding, idempotent reset, selective `--only` execution, `--dry-run` prevention of writes, unknown `--only` rejection, and `--seed` env var lifecycle; all tests passed.
- Ran the project's test suite via `pytest` for sanity on impacted areas; no regressions were observed in the executed test subset.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a62f6ce3e48327a2e3e1cf2b492208)