### PR TITLE
Add asset audit command, legacy fallback logging and deprecation docs

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -120,6 +120,18 @@ Usuarios creados:
 - **Admin**: `ADMIN_USER` / `ADMIN_PASSWORD` (defaults: `admin` / `admin123`)
 - **System**: `SYSTEM_USER` / `SYSTEM_PASSWORD` (defaults: `system` / `system123`)
 
+## Deprecaciones de assets
+
+Para facilitar la retirada progresiva de rutas y respuestas legacy de media:
+
+- Ejecuta `python manage.py seed_audit_assets` para auditar:
+  - assets huérfanos,
+  - duplicados por `original_name` y por contenido (hash SHA-256),
+  - referencias a rutas legacy en campos de texto/JSON.
+- Cuando se active un fallback legacy en serialización se registrará en logs con nivel `WARNING`.
+- La ventana de deprecación por defecto es de **2 releases** antes de eliminar rutas antiguas.
+  - Se puede ajustar con `ASSET_LEGACY_DEPRECATION_RELEASE_WINDOW` en `.env`.
+
 ## Pruebas
 
 ```bash

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -29,6 +29,7 @@ env = environ.Env(
     LLM_GROQ_API_KEY=(str, ""),
     LLM_LOCAL_API_URL=(str, "http://localhost:11434"),
     FCM_CREDENTIALS_FILE=(str, ""),
+    ASSET_LEGACY_DEPRECATION_RELEASE_WINDOW=(int, 2),
 )
 
 ENV_FILE = BASE_DIR / ".env"
@@ -242,3 +243,6 @@ LLM_LOCAL_API_URL = env("LLM_LOCAL_API_URL")
 # EXTERNAL SERVICES
 # ==============================================================================
 FCM_CREDENTIALS_FILE = env("FCM_CREDENTIALS_FILE")
+
+
+ASSET_LEGACY_DEPRECATION_RELEASE_WINDOW = env("ASSET_LEGACY_DEPRECATION_RELEASE_WINDOW")

--- a/backend/events/serializers.py
+++ b/backend/events/serializers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from django.conf import settings
 from django.utils import timezone
 from rest_framework import serializers
@@ -12,6 +14,9 @@ from media_files.models import DocumentFile, ImageFile
 from media_files.serializers import DocumentFileSerializer, ImageFileSerializer
 
 from .models import Event, EventDate
+
+
+logger = logging.getLogger(__name__)
 
 
 class EventTranslationSerializer(serializers.Serializer):
@@ -212,14 +217,26 @@ class EventSerializer(TranslatableModelSerializer):
             return ""
         try:
             data = ImageFileSerializer(obj.featured_media, context=self.context).data
-            return (
+            primary_url = (
                 data.get("variant_large")
                 or data.get("variant_medium")
                 or data.get("file")
-                or data.get("thumbnail_url")
-                or data.get("variant_thumbnail")
-                or ""
             )
+            if primary_url:
+                return primary_url
+
+            legacy_url = data.get("thumbnail_url")
+            if legacy_url:
+                logger.warning(
+                    "Using legacy asset fallback 'thumbnail_url' for event %s (asset %s). "
+                    "Scheduled for removal after %s releases.",
+                    obj.id,
+                    obj.featured_media_id,
+                    settings.ASSET_LEGACY_DEPRECATION_RELEASE_WINDOW,
+                )
+                return legacy_url
+
+            return data.get("variant_thumbnail") or ""
         except Exception:
             return ""
 

--- a/backend/media_files/management/commands/seed_audit_assets.py
+++ b/backend/media_files/management/commands/seed_audit_assets.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any
+
+from django.apps import apps
+from django.conf import settings
+from django.core.files.storage import default_storage
+from django.core.management.base import BaseCommand
+from django.db.models import Field
+
+from media_files.models import DocumentFile, ImageFile, VideoFile
+
+DEFAULT_LEGACY_PATH_MARKERS = (
+    "/media/uploads/",
+    "/legacy/uploads/",
+    "/legacy/media/",
+)
+
+
+@dataclass
+class DuplicateGroup:
+    key: str
+    records: list[str]
+
+
+class Command(BaseCommand):
+    help = (
+        "Audit media assets and report: orphan assets, duplicate assets by name/content, "
+        "and remaining legacy path references."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--legacy-marker",
+            action="append",
+            dest="legacy_markers",
+            default=None,
+            help=(
+                "Legacy path marker to scan for. Can be passed multiple times. "
+                "Defaults to common legacy upload path prefixes."
+            ),
+        )
+        parser.add_argument(
+            "--json",
+            action="store_true",
+            help="Print the report as JSON for scripting.",
+        )
+
+    def handle(self, *args, **options):
+        legacy_markers = tuple(options.get("legacy_markers") or DEFAULT_LEGACY_PATH_MARKERS)
+        report = {
+            "deprecation_window_releases": getattr(
+                settings, "ASSET_LEGACY_DEPRECATION_RELEASE_WINDOW", 2
+            ),
+            "orphan_assets": self._collect_orphan_assets(),
+            "duplicates_by_name": self._collect_duplicates_by_name(),
+            "duplicates_by_content": self._collect_duplicates_by_content(),
+            "legacy_path_references": self._collect_legacy_references(legacy_markers),
+        }
+
+        if options.get("json"):
+            self.stdout.write(json.dumps(report, indent=2, ensure_ascii=False, sort_keys=True))
+            return
+
+        self._print_human_report(report, legacy_markers)
+
+    def _asset_models(self):
+        return (ImageFile, DocumentFile, VideoFile)
+
+    def _collect_orphan_assets(self) -> dict[str, list[str]]:
+        result: dict[str, list[str]] = {}
+        for model in self._asset_models():
+            orphans: list[str] = []
+            for instance in model.objects.all().only("id", "original_name"):
+                if self._is_orphan(instance):
+                    orphans.append(f"{instance.id}:{instance.original_name}")
+            result[model.__name__] = orphans
+        return result
+
+    def _is_orphan(self, instance: Any) -> bool:
+        for relation in instance._meta.related_objects:
+            if relation.related_model._meta.app_label == "simple_history":
+                continue
+            accessor = relation.get_accessor_name()
+            manager_or_object = getattr(instance, accessor)
+            if relation.one_to_one:
+                if manager_or_object is not None:
+                    return False
+                continue
+            if manager_or_object.exists():
+                return False
+        return True
+
+    def _collect_duplicates_by_name(self) -> dict[str, list[list[str]]]:
+        output: dict[str, list[list[str]]] = {}
+        for model in self._asset_models():
+            by_name: dict[str, list[str]] = defaultdict(list)
+            for record in model.objects.all().only("id", "original_name"):
+                key = (record.original_name or "").strip().lower()
+                if not key:
+                    continue
+                by_name[key].append(f"{record.id}:{record.original_name}")
+            output[model.__name__] = [values for values in by_name.values() if len(values) > 1]
+        return output
+
+    def _collect_duplicates_by_content(self) -> dict[str, list[list[str]]]:
+        output: dict[str, list[list[str]]] = {}
+        for model in self._asset_models():
+            by_hash: dict[str, list[str]] = defaultdict(list)
+            for record in model.objects.all().only("id", "original_name", "file"):
+                digest = self._sha256(record.file.name)
+                if not digest:
+                    continue
+                by_hash[digest].append(f"{record.id}:{record.original_name}")
+            output[model.__name__] = [values for values in by_hash.values() if len(values) > 1]
+        return output
+
+    def _sha256(self, path: str) -> str:
+        if not path:
+            return ""
+        if not default_storage.exists(path):
+            return ""
+
+        digest = hashlib.sha256()
+        with default_storage.open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 64), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def _collect_legacy_references(self, markers: tuple[str, ...]) -> dict[str, list[dict[str, Any]]]:
+        result: dict[str, list[dict[str, Any]]] = {marker: [] for marker in markers}
+        for model in apps.get_models():
+            fields = [f for f in model._meta.get_fields() if self._is_text_like_field(f)]
+            if not fields:
+                continue
+
+            field_names = [f.name for f in fields]
+            for obj in model.objects.values("pk", *field_names):
+                pk = obj.get("pk")
+                for field_name in field_names:
+                    value = obj.get(field_name)
+                    if not value:
+                        continue
+                    value_text = self._stringify_value(value)
+                    for marker in markers:
+                        if marker in value_text:
+                            result[marker].append(
+                                {
+                                    "model": f"{model._meta.app_label}.{model.__name__}",
+                                    "pk": pk,
+                                    "field": field_name,
+                                }
+                            )
+        return result
+
+    def _is_text_like_field(self, field: Field) -> bool:
+        internal_type = field.get_internal_type()
+        return internal_type in {"CharField", "TextField", "JSONField", "URLField"}
+
+    def _stringify_value(self, value: Any) -> str:
+        if isinstance(value, str):
+            return value
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+    def _print_human_report(self, report: dict[str, Any], markers: tuple[str, ...]) -> None:
+        self.stdout.write(self.style.MIGRATE_HEADING("Asset audit report"))
+        self.stdout.write(
+            f"Legacy deprecation window: {report['deprecation_window_releases']} release(s)."
+        )
+
+        self.stdout.write(self.style.MIGRATE_HEADING("Orphan assets"))
+        for model, rows in report["orphan_assets"].items():
+            self.stdout.write(f"- {model}: {len(rows)}")
+            for row in rows:
+                self.stdout.write(f"  · {row}")
+
+        self.stdout.write(self.style.MIGRATE_HEADING("Duplicate assets by original_name"))
+        for model, groups in report["duplicates_by_name"].items():
+            self.stdout.write(f"- {model}: {len(groups)} group(s)")
+            for group in groups:
+                self.stdout.write(f"  · {', '.join(group)}")
+
+        self.stdout.write(self.style.MIGRATE_HEADING("Duplicate assets by content hash"))
+        for model, groups in report["duplicates_by_content"].items():
+            self.stdout.write(f"- {model}: {len(groups)} group(s)")
+            for group in groups:
+                self.stdout.write(f"  · {', '.join(group)}")
+
+        self.stdout.write(self.style.MIGRATE_HEADING("Legacy path references"))
+        for marker in markers:
+            rows = report["legacy_path_references"].get(marker, [])
+            self.stdout.write(f"- {marker}: {len(rows)}")
+            for row in rows:
+                self.stdout.write(
+                    f"  · {row['model']} pk={row['pk']} field={row['field']}"
+                )

--- a/backend/media_files/tests/test_seed_audit_assets_command.py
+++ b/backend/media_files/tests/test_seed_audit_assets_command.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+from io import StringIO
+
+from django.core.files.base import ContentFile
+from django.core.management import call_command
+
+from media_files.models import DocumentFile
+
+
+def test_seed_audit_assets_reports_orphans_duplicates_and_legacy_refs(media_storage):
+    shared_content = b"same-content"
+
+    doc1 = DocumentFile.objects.create(
+        file=ContentFile(shared_content, name="dup.pdf"),
+        original_name="legacy://dup.pdf",
+        mime_type="application/pdf",
+        size_bytes=len(shared_content),
+    )
+    doc2 = DocumentFile.objects.create(
+        file=ContentFile(shared_content, name="dup.pdf"),
+        original_name="legacy://dup.pdf",
+        mime_type="application/pdf",
+        size_bytes=len(shared_content),
+    )
+
+    out = StringIO()
+    call_command("seed_audit_assets", "--json", "--legacy-marker", "legacy://", stdout=out)
+    payload = json.loads(out.getvalue())
+
+    assert payload["deprecation_window_releases"] == 2
+    assert any(str(doc1.id) in row for row in payload["orphan_assets"]["DocumentFile"])
+    assert any(str(doc2.id) in row for row in payload["orphan_assets"]["DocumentFile"])
+
+    duplicate_name_groups = payload["duplicates_by_name"]["DocumentFile"]
+    assert any(len(group) == 2 for group in duplicate_name_groups)
+
+    duplicate_hash_groups = payload["duplicates_by_content"]["DocumentFile"]
+    assert any(len(group) == 2 for group in duplicate_hash_groups)
+
+    legacy_hits = payload["legacy_path_references"]["legacy://"]
+    assert any(hit["model"] == "media_files.DocumentFile" for hit in legacy_hits)


### PR DESCRIPTION
### Motivation
- Provide an operational audit to find orphaned/duplicated media and detect code that still references legacy upload paths to enable safe cleanup. 
- Make uses of legacy asset fallbacks observable in logs to help teams remove them later. 
- Document the deprecation policy and give a clear window (releases) before removing legacy routes. 

### Description
- Added a new management command `python manage.py seed_audit_assets` in `backend/media_files/management/commands/` that reports orphan assets, duplicates by `original_name`, duplicates by content (SHA-256), and legacy path references, and supports `--json` and `--legacy-marker` flags. 
- Introduced `ASSET_LEGACY_DEPRECATION_RELEASE_WINDOW` (default `2`) in `backend/config/settings/base.py` to configure the deprecation window. 
- Logged legacy fallback usage in `EventSerializer.get_image_url` with `logger.warning(...)` including event id, asset id and the deprecation window to ease later removal. 
- Documented the policy and the audit command in `backend/README.md` under a new "Deprecaciones de assets" section. 
- Added a unit test `backend/media_files/tests/test_seed_audit_assets_command.py` that exercises the command in JSON mode to validate orphan, duplicate and legacy-marker detection. 

### Testing
- Ran `python backend/manage.py help seed_audit_assets` which printed the command usage successfully. 
- Ran `ruff check` on the new/changed files which passed after minor adjustments. 
- Ran `python -m compileall` on the changed files to validate syntax which succeeded. 
- Added a pytest for the command but running `pytest` in this environment hit project bootstrap limits (`AppRegistryNotReady` while loading `backend/conftest.py`), so full pytest execution was not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7075ae9ec83279711f125e7bbf7be)