### PR TITLE
test(backoffice): refactor test utilities, fixtures and stabilize suites

### DIFF
--- a/backoffice/src/App.test.tsx
+++ b/backoffice/src/App.test.tsx
@@ -1,11 +1,15 @@
-import { describe, it, expect } from "vitest";
-import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@/tests/test-utils";
 import App from "./App";
 
 describe("App", () => {
-  it("renders without crashing", () => {
+  it("renders the backoffice shell information", () => {
     render(<App />);
-    // Simple test to verify the component renders
-    expect(document.body).toBeTruthy();
+
+    expect(
+      screen.getByRole("heading", { name: /gaudeix backoffice/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/panel administrativo listo/i)).toBeInTheDocument();
+    expect(screen.getByText(/api base url/i)).toBeInTheDocument();
   });
 });

--- a/backoffice/src/components/common/PageHeader.test.tsx
+++ b/backoffice/src/components/common/PageHeader.test.tsx
@@ -1,11 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { render, screen } from "@/tests/test-utils";
 import { PageHeader } from "@/components/common";
 
 describe("PageHeader", () => {
-  it("renders title", () => {
+  it("renders title as heading", () => {
     render(<PageHeader title="Test Title" />);
-    expect(screen.getByText("Test Title")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Test Title" }),
+    ).toBeInTheDocument();
   });
 
   it("renders description when provided", () => {
@@ -14,7 +16,12 @@ describe("PageHeader", () => {
   });
 
   it("renders actions when provided", () => {
-    render(<PageHeader title="Test" actions={<button>Action</button>} />);
-    expect(screen.getByText("Action")).toBeInTheDocument();
+    render(
+      <PageHeader
+        title="Test"
+        actions={<button type="button">Action</button>}
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Action" })).toBeInTheDocument();
   });
 });

--- a/backoffice/src/features/auth/tests/Auth.test.tsx
+++ b/backoffice/src/features/auth/tests/Auth.test.tsx
@@ -1,63 +1,53 @@
-import { describe, it, expect } from "vitest";
-import { MemoryRouter, Routes, Route } from "react-router-dom";
-import { render as rtlRender, screen } from "@testing-library/react";
-import { render } from "@/tests/test-utils";
+import { describe, expect, it } from "vitest";
+import { Route, Routes } from "react-router-dom";
+import { render, screen } from "@/tests/test-utils";
 import { LoginPage } from "../pages/LoginPage";
 import { RegisterPage } from "../pages/RegisterPage";
 import { ResetPasswordPage } from "../pages/ResetPasswordPage";
 import { AuthLayout } from "../components/AuthLayout";
 
-// Mock environment variables if needed, but we are using defaults in env.ts so it should be fine.
-
 describe("Auth Feature", () => {
   describe("AuthLayout", () => {
-    it("renders children correctly via Outlet", () => {
-      rtlRender(
-        <MemoryRouter initialEntries={["/test"]}>
-          <Routes>
-            <Route element={<AuthLayout />}>
-              <Route
-                path="/test"
-                element={<div data-testid="child">Child Content</div>}
-              />
-            </Route>
-          </Routes>
-        </MemoryRouter>
+    it("renders children via outlet", () => {
+      render(
+        <Routes>
+          <Route element={<AuthLayout />}>
+            <Route path="/test" element={<h1>Child Content</h1>} />
+          </Route>
+        </Routes>,
+        { router: { type: "memory", initialEntries: ["/test"] } },
       );
-      expect(screen.getByTestId("child")).toBeInTheDocument();
-    });
-  });
 
-  describe("LoginPage", () => {
-    it("renders login form with email and password inputs", () => {
-      render(<LoginPage />);
-      expect(screen.getByLabelText(/usuario o email/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/contraseña/i)).toBeInTheDocument();
       expect(
-        screen.getByRole("button", { name: /iniciar sesión/i })
+        screen.getByRole("heading", { name: "Child Content" }),
       ).toBeInTheDocument();
     });
   });
 
-  describe("RegisterPage", () => {
-    it("renders register form with all inputs", () => {
-      render(<RegisterPage />);
-      expect(screen.getByLabelText(/correo electrónico/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/^contraseña$/i)).toBeInTheDocument();
-      expect(screen.getByLabelText(/confirmar contraseña/i)).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: /registrarse/i })
-      ).toBeInTheDocument();
-    });
+  it("renders login form", () => {
+    render(<LoginPage />);
+    expect(screen.getByLabelText(/usuario o email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/contraseña/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /iniciar sesión/i }),
+    ).toBeInTheDocument();
   });
 
-  describe("ResetPasswordPage", () => {
-    it("renders reset password form", () => {
-      render(<ResetPasswordPage />);
-      expect(screen.getByLabelText(/correo electrónico/i)).toBeInTheDocument();
-      expect(
-        screen.getByRole("button", { name: /enviar instrucciones/i })
-      ).toBeInTheDocument();
-    });
+  it("renders register form", () => {
+    render(<RegisterPage />);
+    expect(screen.getByLabelText(/correo electrónico/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^contraseña$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/confirmar contraseña/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /registrarse/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders reset password form", () => {
+    render(<ResetPasswordPage />);
+    expect(screen.getByLabelText(/correo electrónico/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /enviar instrucciones/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/backoffice/src/features/events/tests/EventDates.test.tsx
+++ b/backoffice/src/features/events/tests/EventDates.test.tsx
@@ -1,9 +1,8 @@
-import { describe, test, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "@/tests/test-utils";
 import { EventDialog } from "../components/EventDialog";
-import React from "react";
 
-// Mock child components or modules
 vi.mock("../api/events", () => ({
   eventsApi: {
     getOccurrences: vi.fn().mockResolvedValue([]),
@@ -29,25 +28,21 @@ vi.mock("@/features/tags/api/tags", () => ({
   },
 }));
 
-// Mock EventPreview to avoid resolving @frontend alias in test environment
 vi.mock("../components/EventPreview", () => ({
   EventPreview: () => null,
 }));
 
-describe("EventDialog Logic", () => {
+describe("EventDialog dates", () => {
   const mockOnSubmit = vi.fn();
   const mockOnOpenChange = vi.fn();
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    mockOnSubmit.mockReset();
+    mockOnOpenChange.mockReset();
   });
 
-  test("sanity check", () => {
-    expect(1 + 1).toBe(2);
-  });
-
-  test("adds a date", async () => {
-    const { container } = render(
+  const openDatesTab = async () => {
+    const view = render(
       <EventDialog
         open={true}
         onOpenChange={mockOnOpenChange}
@@ -55,50 +50,47 @@ describe("EventDialog Logic", () => {
       />,
     );
 
-    const datesTab = screen.getByRole("button", { name: /fechas/i });
-    fireEvent.click(datesTab);
+    await userEvent.click(screen.getByRole("button", { name: /fechas/i }));
+    return view;
+  };
 
-    // Label association is missing in component, using selector
-    const startInput = container.querySelector('input[type="datetime-local"]');
-    if (!startInput) throw new Error("Start date input not found");
+  it("adds a date row", async () => {
+    const { container } = await openDatesTab();
 
-    fireEvent.change(startInput, { target: { value: "2026-02-01T10:00" } });
+    const startInput = container.querySelector(
+      'input[type="datetime-local"]',
+    ) as HTMLInputElement | null;
+    expect(startInput).not.toBeNull();
 
-    const addButton = screen.getByRole("button", { name: /registrar fecha/i });
-    fireEvent.click(addButton);
+    await userEvent.type(startInput!, "2026-02-01T10:00");
+    await userEvent.click(
+      screen.getByRole("button", { name: /registrar fecha/i }),
+    );
 
     await waitFor(() => {
       expect(screen.getByText(/2026/)).toBeInTheDocument();
     });
   });
 
-  test("prevents overlapping sessions", async () => {
-    const { container } = render(
-      <EventDialog
-        open={true}
-        onOpenChange={mockOnOpenChange}
-        onSubmit={mockOnSubmit}
-      />,
+  it("prevents overlapping sessions", async () => {
+    const { container } = await openDatesTab();
+
+    const startInput = container.querySelector(
+      'input[type="datetime-local"]',
+    ) as HTMLInputElement | null;
+    expect(startInput).not.toBeNull();
+
+    await userEvent.type(startInput!, "2026-02-01T10:00");
+    await userEvent.click(
+      screen.getByRole("button", { name: /registrar fecha/i }),
     );
 
-    const datesTab = screen.getByRole("button", { name: /fechas/i });
-    fireEvent.click(datesTab);
+    await userEvent.clear(startInput!);
+    await userEvent.type(startInput!, "2026-02-01T10:30");
+    await userEvent.click(
+      screen.getByRole("button", { name: /registrar fecha/i }),
+    );
 
-    const startInput = container.querySelector('input[type="datetime-local"]');
-    if (!startInput) throw new Error("Start date input not found");
-
-    // Add first session
-    fireEvent.change(startInput, { target: { value: "2026-02-01T10:00" } });
-    const addButton = screen.getByRole("button", { name: /registrar fecha/i });
-    fireEvent.click(addButton);
-
-    // Attempt to add overlapping session
-    fireEvent.change(startInput, { target: { value: "2026-02-01T10:30" } });
-    fireEvent.click(addButton);
-
-    // Should show error toast (mocked or checked via behavior)
-    // Since we use sonner, we can check if the session was NOT added
-    const rows = container.querySelectorAll("tbody tr");
-    expect(rows.length).toBe(1);
+    expect(container.querySelectorAll("tbody tr")).toHaveLength(1);
   });
 });

--- a/backoffice/src/features/festes/tests/ProgrammingCRUD.test.tsx
+++ b/backoffice/src/features/festes/tests/ProgrammingCRUD.test.tsx
@@ -3,7 +3,7 @@
  * Tests ProgramsPage rendering with mocked API.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@/tests/test-utils";
 import userEvent from "@testing-library/user-event";
 import { ProgramsPage } from "../pages/ProgramsPage";
 import { Program, Festa } from "../types";

--- a/backoffice/src/features/landing/tests/LandingPage.test.tsx
+++ b/backoffice/src/features/landing/tests/LandingPage.test.tsx
@@ -1,76 +1,46 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { BrowserRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@/tests/test-utils";
 import { LandingPage } from "../pages/LandingPage";
 
-const renderWithRouter = (component: React.ReactNode) => {
-  return render(<BrowserRouter>{component}</BrowserRouter>);
-};
+const mockHealthcheck = (database: "ok" | "error" = "ok") =>
+  vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ status: "online", database }),
+  } as unknown as Response);
+
+const renderLanding = () =>
+  render(<LandingPage />, {
+    router: { type: "memory", initialEntries: ["/"] },
+  });
 
 describe("LandingPage", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.restoreAllMocks();
-  });
+  it("renders title and description", () => {
+    mockHealthcheck();
 
-  it("renders the landing page with title and description", () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ status: "online", database: "ok" }),
-    } as unknown as Response);
+    renderLanding();
 
-    renderWithRouter(<LandingPage />);
-
-    expect(screen.getByText("Gaudeix Codex")).toBeInTheDocument();
-    expect(screen.getByText("Panel de Administración")).toBeInTheDocument();
-  });
-
-  it("shows frontend status as online", () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ status: "online", database: "ok" }),
-    } as unknown as Response);
-
-    renderWithRouter(<LandingPage />);
-
-    expect(screen.getByText("Frontend")).toBeInTheDocument();
-    expect(screen.getAllByText("Backoffice").length).toBeGreaterThan(0);
+    expect(screen.getByText(/gaudeix codex/i)).toBeInTheDocument();
+    expect(screen.getByText(/panel de administración/i)).toBeInTheDocument();
   });
 
   it("calls health check on mount", async () => {
-    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ status: "online", database: "ok" }),
-    } as unknown as Response);
+    const fetchSpy = mockHealthcheck();
 
-    renderWithRouter(<LandingPage />);
+    renderLanding();
 
     await waitFor(() => {
-      expect(fetchSpy).toHaveBeenCalled();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
   });
 
   it("shows backend as online when health check succeeds", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ status: "online", database: "ok" }),
-    } as unknown as Response);
+    mockHealthcheck();
 
-    renderWithRouter(<LandingPage />);
+    renderLanding();
 
-    // Initially shows "Verificando..."
     expect(screen.getByText(/verificando/i)).toBeInTheDocument();
-
-    // After health check, shows "Online"
-    await waitFor(() => {
-      const badges = screen.getAllByText("Online");
-      expect(badges.length).toBeGreaterThan(0);
-    });
-
-    // Django API + PostgreSQL checks should be OK
-    await waitFor(() => {
-      expect(screen.getAllByText("✓").length).toBeGreaterThanOrEqual(2);
-    });
+    expect(await screen.findByText("Online")).toBeInTheDocument();
+    expect(screen.getAllByText("✓").length).toBeGreaterThanOrEqual(2);
   });
 
   it("shows backend as offline when health check fails", async () => {
@@ -78,47 +48,29 @@ describe("LandingPage", () => {
       new Error("Network error"),
     );
 
-    renderWithRouter(<LandingPage />);
+    renderLanding();
 
-    // Initially shows "Verificando..."
     expect(screen.getByText(/verificando/i)).toBeInTheDocument();
-
-    // After health check fails, shows "Offline"
-    await waitFor(() => {
-      expect(screen.getByText("Offline")).toBeInTheDocument();
-    });
+    expect(await screen.findByText("Offline")).toBeInTheDocument();
   });
 
-  it("shows database error when health check returns error status", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ status: "online", database: "error" }),
-    } as unknown as Response);
+  it("shows database error when health check returns db error", async () => {
+    mockHealthcheck("error");
 
-    renderWithRouter(<LandingPage />);
+    renderLanding();
 
-    await waitFor(() => {
-      const badges = screen.getAllByText("Online");
-      expect(badges.length).toBeGreaterThan(0);
-    });
-
-    await waitFor(() => {
-      expect(screen.getAllByText("✗").length).toBeGreaterThan(0);
-    });
+    expect(await screen.findByText("Online")).toBeInTheDocument();
+    expect(screen.getAllByText("✗").length).toBeGreaterThan(0);
   });
 
-  it("renders login button with correct link", () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ status: "online", database: "ok" }),
-    } as unknown as Response);
+  it("renders login link", () => {
+    mockHealthcheck();
 
-    renderWithRouter(<LandingPage />);
+    renderLanding();
 
     const loginButton = screen.getByRole("link", {
       name: /acceder al backoffice/i,
     });
-    expect(loginButton).toBeInTheDocument();
     expect(loginButton).toHaveAttribute("href", "/login");
   });
 });

--- a/backoffice/src/features/notifications/tests/SendNotificationPage.test.tsx
+++ b/backoffice/src/features/notifications/tests/SendNotificationPage.test.tsx
@@ -1,12 +1,17 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@/tests/test-utils";
 import { SendNotificationPage } from "../pages/SendNotificationPage";
 
-// Mock API
 vi.mock("../api", () => ({
-  getNotificationHistory: vi
-    .fn()
-    .mockResolvedValue([
+  getNotificationHistory: vi.fn(),
+  sendNotification: vi.fn().mockResolvedValue(true),
+}));
+
+import { getNotificationHistory } from "../api";
+
+describe("SendNotificationPage", () => {
+  beforeEach(() => {
+    vi.mocked(getNotificationHistory).mockResolvedValue([
       {
         id: 1,
         title: "Test Notification",
@@ -14,19 +19,20 @@ vi.mock("../api", () => ({
         recipient_count: 100,
         status: "sent",
       },
-    ]),
-  sendNotification: vi.fn().mockResolvedValue(true),
-}));
+    ]);
+  });
 
-describe("SendNotificationPage", () => {
-  it("renders the form and history", async () => {
+  it("renders campaign form and notification history", async () => {
     render(<SendNotificationPage />);
 
-    expect(screen.getByText("Push Notifications")).toBeInTheDocument();
-    expect(screen.getByText("Nueva Campaña")).toBeInTheDocument();
-    expect(screen.getByLabelText(/Título/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /push notifications/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /nueva campaña/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/título/i)).toBeInTheDocument();
 
-    // Check for history item
     expect(await screen.findByText("Test Notification")).toBeInTheDocument();
   });
 });

--- a/backoffice/src/features/routes/tests/RoutesPage.test.tsx
+++ b/backoffice/src/features/routes/tests/RoutesPage.test.tsx
@@ -3,7 +3,7 @@
  * Tests RoutesPage rendering + RouteDialog submit behavior.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@/tests/test-utils";
 import userEvent from "@testing-library/user-event";
 import { RoutesPage } from "../pages/RoutesPage";
 import { Route } from "../types";
@@ -11,51 +11,51 @@ import { Route } from "../types";
 // ── Mock APIs ──────────────────────────────────────────────
 
 vi.mock("../api/routes", () => ({
-    routesApi: {
-        getAll: vi.fn(),
-        create: vi.fn(),
-        update: vi.fn(),
-        delete: vi.fn(),
-        generateGpx: vi.fn(),
-        autoTranslate: vi.fn(),
-    },
+  routesApi: {
+    getAll: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    generateGpx: vi.fn(),
+    autoTranslate: vi.fn(),
+  },
 }));
 
 vi.mock("@/features/media/api/media", () => ({
-    mediaApi: {
-        listImages: vi.fn().mockResolvedValue([]),
-        listDocuments: vi.fn().mockResolvedValue([]),
-        listVideos: vi.fn().mockResolvedValue([]),
-        upload: vi.fn(),
-        delete: vi.fn(),
-    },
+  mediaApi: {
+    listImages: vi.fn().mockResolvedValue([]),
+    listDocuments: vi.fn().mockResolvedValue([]),
+    listVideos: vi.fn().mockResolvedValue([]),
+    upload: vi.fn(),
+    delete: vi.fn(),
+  },
 }));
 
 vi.mock("@/features/categories/api/categories", () => ({
-    categoriesApi: {
-        list: vi.fn().mockResolvedValue([]),
-    },
+  categoriesApi: {
+    list: vi.fn().mockResolvedValue([]),
+  },
 }));
 
 vi.mock("@/features/tags/api/tags", () => ({
-    tagsApi: {
-        list: vi.fn().mockResolvedValue([]),
-    },
+  tagsApi: {
+    list: vi.fn().mockResolvedValue([]),
+  },
 }));
 
 vi.mock("@/features/places/api/places", () => ({
-    placesApi: {
-        getAll: vi.fn().mockResolvedValue([]),
-    },
+  placesApi: {
+    getAll: vi.fn().mockResolvedValue([]),
+  },
 }));
 
 // Mock sonner toasts
 vi.mock("sonner", () => ({
-    toast: {
-        success: vi.fn(),
-        error: vi.fn(),
-        info: vi.fn(),
-    },
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
 }));
 
 import { routesApi } from "../api/routes";
@@ -63,268 +63,277 @@ import { routesApi } from "../api/routes";
 // ── Fixtures ────────────────────────────────────────────────
 
 const mockRoute: Route = {
-    id: 1,
-    slug: "coastal-loop",
-    title: "Coastal Loop",
-    summary: "A coastal hiking route",
-    description: "Full description",
-    instructions: "Follow the trail markers",
-    route_type: "walking",
-    difficulty: "moderate",
-    distance_km: 12.4,
-    duration_minutes: 215,
-    duration_formatted: "3h 35m",
-    elevation_gain: 430,
-    elevation_loss: 420,
-    start_latitude: 41.6205,
-    start_longitude: 2.6878,
-    end_latitude: 41.64,
-    end_longitude: 2.705,
-    is_circular: true,
-    is_published: true,
-    is_featured: false,
-    tags: [],
-    featured_media: null,
-    gpx_file: null,
-    attachments: [],
-    gallery: [],
-    waypoints_list: [],
-    checkpoints_list: [],
-    created_at: "2024-01-01T00:00:00Z",
-    updated_at: "2024-01-01T00:00:00Z",
+  id: 1,
+  slug: "coastal-loop",
+  title: "Coastal Loop",
+  summary: "A coastal hiking route",
+  description: "Full description",
+  instructions: "Follow the trail markers",
+  route_type: "walking",
+  difficulty: "moderate",
+  distance_km: 12.4,
+  duration_minutes: 215,
+  duration_formatted: "3h 35m",
+  elevation_gain: 430,
+  elevation_loss: 420,
+  start_latitude: 41.6205,
+  start_longitude: 2.6878,
+  end_latitude: 41.64,
+  end_longitude: 2.705,
+  is_circular: true,
+  is_published: true,
+  is_featured: false,
+  tags: [],
+  featured_media: null,
+  gpx_file: null,
+  attachments: [],
+  gallery: [],
+  waypoints_list: [],
+  checkpoints_list: [],
+  created_at: "2024-01-01T00:00:00Z",
+  updated_at: "2024-01-01T00:00:00Z",
 };
 
 const mockRouteWithGpx: Route = {
-    ...mockRoute,
-    gpx_file: {
-        id: 55,
-        type: "document",
-        original_name: "coastal-loop.gpx",
-        mime_type: "application/gpx+xml",
-        size_bytes: 1198,
-        file: "/media/uploads/documents/abc123.gpx",
-    },
+  ...mockRoute,
+  gpx_file: {
+    id: 55,
+    type: "document",
+    original_name: "coastal-loop.gpx",
+    mime_type: "application/gpx+xml",
+    size_bytes: 1198,
+    file: "/media/uploads/documents/abc123.gpx",
+  },
 };
 
 // ── Tests ───────────────────────────────────────────────────
 
 describe("RoutesPage", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-    it("shows loading state initially", async () => {
-        vi.mocked(routesApi.getAll).mockImplementation(() => new Promise(() => { }));
-        render(<RoutesPage />);
-        expect(screen.getByText("Cargando rutas...")).toBeInTheDocument();
-    });
+  it("shows loading state initially", async () => {
+    vi.mocked(routesApi.getAll).mockImplementation(() => new Promise(() => {}));
+    render(<RoutesPage />);
+    expect(screen.getByText("Cargando rutas...")).toBeInTheDocument();
+  });
 
-    it("shows error state when API fails", async () => {
-        vi.mocked(routesApi.getAll).mockRejectedValue(new Error("Network error"));
-        render(<RoutesPage />);
-        await waitFor(() => {
-            expect(screen.getByText("Error al cargar las rutas.")).toBeInTheDocument();
-        });
+  it("shows error state when API fails", async () => {
+    vi.mocked(routesApi.getAll).mockRejectedValue(new Error("Network error"));
+    render(<RoutesPage />);
+    await waitFor(() => {
+      expect(
+        screen.getByText("Error al cargar las rutas."),
+      ).toBeInTheDocument();
     });
+  });
 
-    it("displays routes in table", async () => {
-        vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
-        render(<RoutesPage />);
-        await waitFor(() => {
-            expect(screen.getByText("Coastal Loop")).toBeInTheDocument();
-        });
+  it("displays routes in table", async () => {
+    vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
+    render(<RoutesPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Coastal Loop")).toBeInTheDocument();
     });
+  });
 
-    it("has new route button", async () => {
-        vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
-        render(<RoutesPage />);
-        await waitFor(() => {
-            expect(screen.getByRole("button", { name: /Nueva ruta/i })).toBeInTheDocument();
-        });
+  it("has new route button", async () => {
+    vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
+    render(<RoutesPage />);
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Nueva ruta/i }),
+      ).toBeInTheDocument();
     });
+  });
 
-    it("shows published badge for published routes", async () => {
-        vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
-        render(<RoutesPage />);
-        await waitFor(() => {
-            expect(screen.getByText("Publicada")).toBeInTheDocument();
-        });
+  it("shows published badge for published routes", async () => {
+    vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
+    render(<RoutesPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Publicada")).toBeInTheDocument();
     });
+  });
 
-    it("shows draft badge for unpublished routes", async () => {
-        const draftRoute = { ...mockRoute, is_published: false, slug: "draft", title: "Draft Route" };
-        vi.mocked(routesApi.getAll).mockResolvedValue([draftRoute]);
-        render(<RoutesPage />);
-        await waitFor(() => {
-            expect(screen.getByText("Borrador")).toBeInTheDocument();
-        });
+  it("shows draft badge for unpublished routes", async () => {
+    const draftRoute = {
+      ...mockRoute,
+      is_published: false,
+      slug: "draft",
+      title: "Draft Route",
+    };
+    vi.mocked(routesApi.getAll).mockResolvedValue([draftRoute]);
+    render(<RoutesPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Borrador")).toBeInTheDocument();
     });
+  });
 
-    it("has pagination info", async () => {
-        vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
-        render(<RoutesPage />);
-        await waitFor(() => {
-            expect(screen.getByText(/Página 1 de 1/)).toBeInTheDocument();
-        });
+  it("has pagination info", async () => {
+    vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
+    render(<RoutesPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Página 1 de 1/)).toBeInTheDocument();
     });
+  });
 });
 
 describe("RouteDialog - Form Submit", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("opens edit dialog when edit button is clicked", async () => {
+    vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
+    render(<RoutesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Coastal Loop")).toBeInTheDocument();
     });
 
-    it("opens edit dialog when edit button is clicked", async () => {
-        vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
-        render(<RoutesPage />);
+    const editBtn = screen.getByLabelText("Editar Coastal Loop");
+    await userEvent.click(editBtn);
 
-        await waitFor(() => {
-            expect(screen.getByText("Coastal Loop")).toBeInTheDocument();
-        });
+    await waitFor(() => {
+      expect(screen.getByText("Editar ruta")).toBeInTheDocument();
+    });
+  });
 
-        const editBtn = screen.getByLabelText("Editar Coastal Loop");
-        await userEvent.click(editBtn);
+  it("sends update WITH gpx_file_id in payload to preserve GPX state", async () => {
+    vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
+    vi.mocked(routesApi.update).mockResolvedValue(mockRoute);
+    render(<RoutesPage />);
 
-        await waitFor(() => {
-            expect(screen.getByText("Editar ruta")).toBeInTheDocument();
-        });
+    await waitFor(() => {
+      expect(screen.getByText("Coastal Loop")).toBeInTheDocument();
     });
 
-    it("sends update WITH gpx_file_id in payload to preserve GPX state", async () => {
-        vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
-        vi.mocked(routesApi.update).mockResolvedValue(mockRoute);
-        render(<RoutesPage />);
-
-        await waitFor(() => {
-            expect(screen.getByText("Coastal Loop")).toBeInTheDocument();
-        });
-
-        // Open edit dialog
-        await userEvent.click(screen.getByLabelText("Editar Coastal Loop"));
-        await waitFor(() => {
-            expect(screen.getByText("Editar ruta")).toBeInTheDocument();
-        });
-
-        // Submit the form
-        const saveButton = screen.getByRole("button", { name: /Guardar/i });
-        await userEvent.click(saveButton);
-
-        await waitFor(() => {
-            expect(routesApi.update).toHaveBeenCalled();
-        });
-
-        // gpx_file_id IS included in payload (null for routes without GPX)
-        const payload = vi.mocked(routesApi.update).mock.calls[0][1];
-        expect(payload).toHaveProperty("gpx_file_id", null);
+    // Open edit dialog
+    await userEvent.click(screen.getByLabelText("Editar Coastal Loop"));
+    await waitFor(() => {
+      expect(screen.getByText("Editar ruta")).toBeInTheDocument();
     });
 
-    it("preserves other form fields when saving (no data loss)", async () => {
-        vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
-        vi.mocked(routesApi.update).mockResolvedValue(mockRoute);
-        render(<RoutesPage />);
+    // Submit the form
+    const saveButton = screen.getByRole("button", { name: /Guardar/i });
+    await userEvent.click(saveButton);
 
-        await waitFor(() => {
-            expect(screen.getByText("Coastal Loop")).toBeInTheDocument();
-        });
-
-        await userEvent.click(screen.getByLabelText("Editar Coastal Loop"));
-        await waitFor(() => {
-            expect(screen.getByText("Editar ruta")).toBeInTheDocument();
-        });
-
-        const saveButton = screen.getByRole("button", { name: /Guardar/i });
-        await userEvent.click(saveButton);
-
-        await waitFor(() => {
-            expect(routesApi.update).toHaveBeenCalled();
-        });
-
-        const payload = vi.mocked(routesApi.update).mock.calls[0][1];
-        // Title, route_type, difficulty should be preserved
-        expect(payload).toHaveProperty("title", "Coastal Loop");
-        expect(payload).toHaveProperty("route_type", "walking");
-        expect(payload).toHaveProperty("difficulty", "moderate");
-        // M2M arrays should be present
-        expect(payload).toHaveProperty("tag_ids");
-        expect(payload).toHaveProperty("gallery_ids");
-        expect(payload).toHaveProperty("attachments_ids");
+    await waitFor(() => {
+      expect(routesApi.update).toHaveBeenCalled();
     });
+
+    // gpx_file_id IS included in payload (null for routes without GPX)
+    const payload = vi.mocked(routesApi.update).mock.calls[0][1];
+    expect(payload).toHaveProperty("gpx_file_id", null);
+  });
+
+  it("preserves other form fields when saving (no data loss)", async () => {
+    vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
+    vi.mocked(routesApi.update).mockResolvedValue(mockRoute);
+    render(<RoutesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Coastal Loop")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByLabelText("Editar Coastal Loop"));
+    await waitFor(() => {
+      expect(screen.getByText("Editar ruta")).toBeInTheDocument();
+    });
+
+    const saveButton = screen.getByRole("button", { name: /Guardar/i });
+    await userEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(routesApi.update).toHaveBeenCalled();
+    });
+
+    const payload = vi.mocked(routesApi.update).mock.calls[0][1];
+    // Title, route_type, difficulty should be preserved
+    expect(payload).toHaveProperty("title", "Coastal Loop");
+    expect(payload).toHaveProperty("route_type", "walking");
+    expect(payload).toHaveProperty("difficulty", "moderate");
+    // M2M arrays should be present
+    expect(payload).toHaveProperty("tag_ids");
+    expect(payload).toHaveProperty("gallery_ids");
+    expect(payload).toHaveProperty("attachments_ids");
+  });
 });
 
 describe("RouteDialog - GPX Generation", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls generateGpx API when Generate button is clicked", async () => {
+    vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
+    vi.mocked(routesApi.generateGpx).mockResolvedValue(mockRouteWithGpx);
+    render(<RoutesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Coastal Loop")).toBeInTheDocument();
     });
 
-    it("calls generateGpx API when Generate button is clicked", async () => {
-        vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
-        vi.mocked(routesApi.generateGpx).mockResolvedValue(mockRouteWithGpx);
-        render(<RoutesPage />);
-
-        await waitFor(() => {
-            expect(screen.getByText("Coastal Loop")).toBeInTheDocument();
-        });
-
-        // Open edit dialog
-        await userEvent.click(screen.getByLabelText("Editar Coastal Loop"));
-        await waitFor(() => {
-            expect(screen.getByText("Editar ruta")).toBeInTheDocument();
-        });
-
-        // Switch to Media & Extras tab
-        const mediaTabTrigger = screen.getByText("Media & Extras");
-        await userEvent.click(mediaTabTrigger);
-
-        // Click Generate GPX
-        await waitFor(() => {
-            expect(screen.getByText(/Generar/i)).toBeInTheDocument();
-        });
-        const generateBtn = screen.getByText(/Generar/i).closest("button")!;
-        await userEvent.click(generateBtn);
-
-        await waitFor(() => {
-            expect(routesApi.generateGpx).toHaveBeenCalledWith("coastal-loop");
-        });
+    // Open edit dialog
+    await userEvent.click(screen.getByLabelText("Editar Coastal Loop"));
+    await waitFor(() => {
+      expect(screen.getByText("Editar ruta")).toBeInTheDocument();
     });
 
-    it("submit after GPX generation includes gpx_file_id with correct value", async () => {
-        vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
-        vi.mocked(routesApi.generateGpx).mockResolvedValue(mockRouteWithGpx);
-        vi.mocked(routesApi.update).mockResolvedValue(mockRouteWithGpx);
-        render(<RoutesPage />);
+    // Switch to Media & Extras tab
+    const mediaTabTrigger = screen.getByText("Media & Extras");
+    await userEvent.click(mediaTabTrigger);
 
-        await waitFor(() => {
-            expect(screen.getByText("Coastal Loop")).toBeInTheDocument();
-        });
-
-        // Open edit dialog
-        await userEvent.click(screen.getByLabelText("Editar Coastal Loop"));
-        await waitFor(() => {
-            expect(screen.getByText("Editar ruta")).toBeInTheDocument();
-        });
-
-        // Go to media tab and generate GPX
-        await userEvent.click(screen.getByText("Media & Extras"));
-        await waitFor(() => {
-            expect(screen.getByText(/Generar/i)).toBeInTheDocument();
-        });
-        const generateBtn = screen.getByText(/Generar/i).closest("button")!;
-        await userEvent.click(generateBtn);
-
-        await waitFor(() => {
-            expect(routesApi.generateGpx).toHaveBeenCalled();
-        });
-
-        // Now save the form
-        const saveButton = screen.getByRole("button", { name: /Guardar/i });
-        await userEvent.click(saveButton);
-
-        await waitFor(() => {
-            expect(routesApi.update).toHaveBeenCalled();
-        });
-
-        // CRITICAL: gpx_file_id MUST be in PATCH with the generated GPX ID
-        const payload = vi.mocked(routesApi.update).mock.calls[0][1];
-        expect(payload).toHaveProperty("gpx_file_id", 55);
+    // Click Generate GPX
+    await waitFor(() => {
+      expect(screen.getByText(/Generar/i)).toBeInTheDocument();
     });
+    const generateBtn = screen.getByText(/Generar/i).closest("button")!;
+    await userEvent.click(generateBtn);
+
+    await waitFor(() => {
+      expect(routesApi.generateGpx).toHaveBeenCalledWith("coastal-loop");
+    });
+  });
+
+  it("submit after GPX generation includes gpx_file_id with correct value", async () => {
+    vi.mocked(routesApi.getAll).mockResolvedValue([mockRoute]);
+    vi.mocked(routesApi.generateGpx).mockResolvedValue(mockRouteWithGpx);
+    vi.mocked(routesApi.update).mockResolvedValue(mockRouteWithGpx);
+    render(<RoutesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Coastal Loop")).toBeInTheDocument();
+    });
+
+    // Open edit dialog
+    await userEvent.click(screen.getByLabelText("Editar Coastal Loop"));
+    await waitFor(() => {
+      expect(screen.getByText("Editar ruta")).toBeInTheDocument();
+    });
+
+    // Go to media tab and generate GPX
+    await userEvent.click(screen.getByText("Media & Extras"));
+    await waitFor(() => {
+      expect(screen.getByText(/Generar/i)).toBeInTheDocument();
+    });
+    const generateBtn = screen.getByText(/Generar/i).closest("button")!;
+    await userEvent.click(generateBtn);
+
+    await waitFor(() => {
+      expect(routesApi.generateGpx).toHaveBeenCalled();
+    });
+
+    // Now save the form
+    const saveButton = screen.getByRole("button", { name: /Guardar/i });
+    await userEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(routesApi.update).toHaveBeenCalled();
+    });
+
+    // CRITICAL: gpx_file_id MUST be in PATCH with the generated GPX ID
+    const payload = vi.mocked(routesApi.update).mock.calls[0][1];
+    expect(payload).toHaveProperty("gpx_file_id", 55);
+  });
 });

--- a/backoffice/src/features/social/tests/SocialLinks.test.tsx
+++ b/backoffice/src/features/social/tests/SocialLinks.test.tsx
@@ -1,5 +1,7 @@
-import { render, screen, fireEvent, waitFor } from "@/tests/test-utils";
+import { render, screen, waitFor } from "@/tests/test-utils";
 import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { mockSocialLinks } from "@/tests/fixtures/crudData";
 import { SocialLinksPage } from "../pages/SocialLinksPage";
 import { socialLinksApi } from "../api/socialLinks";
 
@@ -30,85 +32,40 @@ vi.mock("@/components/common", () => ({
   ),
 }));
 
-const MOCK_LINKS = [
-  {
-    id: 1,
-    name: "Facebook",
-    url: "https://facebook.com",
-    icon_class: "fa-brands fa-facebook",
-    color: "#3b5998",
-    available_in_ca: true,
-    available_in_es: true,
-    available_in_en: true,
-    available_in_fr: false,
-    order: 1,
-    is_active: true,
-  },
-  {
-    id: 2,
-    name: "Instagram",
-    url: "https://instagram.com",
-    icon_class: "fa-brands fa-instagram",
-    color: "#E1306C",
-    available_in_ca: true,
-    available_in_es: true,
-    available_in_en: true,
-    available_in_fr: false,
-    order: 2,
-    is_active: false,
-  },
-];
-
 describe("SocialLinksPage CRUD", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    (socialLinksApi.getAll as Mock).mockResolvedValue(MOCK_LINKS);
+    (socialLinksApi.getAll as Mock).mockResolvedValue([...mockSocialLinks]);
   });
 
   it("renders social links and fetches data", async () => {
     render(<SocialLinksPage />);
 
-    expect(screen.getByText("Enlaces sociales")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /enlaces sociales/i }),
+    ).toBeInTheDocument();
     expect(screen.getByText(/cargando/i)).toBeInTheDocument();
+    expect(await screen.findByText("Facebook")).toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(screen.getByText("Facebook")).toBeInTheDocument();
-    });
-
-    expect(socialLinksApi.getAll).toHaveBeenCalled();
+    expect(socialLinksApi.getAll).toHaveBeenCalledTimes(1);
     expect(screen.getByText("Instagram")).toBeInTheDocument();
   });
 
-  it("deletes a social link", async () => {
+  it("deletes a social link and refetches list", async () => {
     (socialLinksApi.delete as Mock).mockResolvedValue({});
 
     render(<SocialLinksPage />);
-
-    await waitFor(() => {
-      expect(screen.getByText("Facebook")).toBeInTheDocument();
-    });
+    expect(await screen.findByText("Facebook")).toBeInTheDocument();
 
     const deleteButtons = screen.getAllByRole("button", { name: /eliminar/i });
+    await userEvent.click(deleteButtons[0]);
 
-    // Click delete button to open AlertDialog
-    fireEvent.click(deleteButtons[0]);
-
-    // Wait for confirmation dialog to appear
-    await waitFor(() => {
-      expect(screen.getByText(/¿Estás seguro/i)).toBeInTheDocument();
+    const confirmButton = await screen.findByRole("button", {
+      name: /^Eliminar$/,
     });
+    await userEvent.click(confirmButton);
 
-    // Find and click the confirmation button by its text content
-    const confirmButton = screen.getByRole("button", { name: /^Eliminar$/ });
-    fireEvent.click(confirmButton);
-
-    // Should call delete API
     await waitFor(() => {
       expect(socialLinksApi.delete).toHaveBeenCalledWith(1);
-    });
-
-    // Should refetch after deletion
-    await waitFor(() => {
       expect(socialLinksApi.getAll).toHaveBeenCalledTimes(2);
     });
   });

--- a/backoffice/src/features/users/tests/UsersCrud.test.tsx
+++ b/backoffice/src/features/users/tests/UsersCrud.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "@/tests/test-utils";
+import { mockUsers } from "@/tests/fixtures/crudData";
 import { UsersPage } from "../pages/UsersPage";
 import { usersApi } from "../api/users";
 
-// Mock the API
 vi.mock("../api/users", () => ({
   usersApi: {
     getAll: vi.fn(),
@@ -13,7 +14,6 @@ vi.mock("../api/users", () => ({
   },
 }));
 
-// Mock the components that are not implemented yet or complex
 vi.mock("@/components/common", () => ({
   PageContainer: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
@@ -32,78 +32,39 @@ vi.mock("@/components/common", () => ({
   ),
 }));
 
-const MOCK_USERS = [
-  {
-    id: 1,
-    username: "admin",
-    email: "admin@gaudeix.com",
-    name: "Admin User",
-    is_staff: true,
-    is_active: true,
-    date_joined: "2023-01-01T00:00:00Z",
-  },
-  {
-    id: 2,
-    username: "user",
-    email: "user@gaudeix.com",
-    name: "Regular User",
-    is_staff: false,
-    is_active: true,
-    date_joined: "2023-01-02T00:00:00Z",
-  },
-];
-
 describe("UsersPage CRUD", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    (usersApi.getAll as Mock).mockResolvedValue(MOCK_USERS);
+    (usersApi.getAll as Mock).mockResolvedValue([...mockUsers]);
   });
 
-  it("renders the users page and fetches users", async () => {
+  it("renders users and fetches initial list", async () => {
     render(<UsersPage />);
 
     expect(
       screen.getByRole("heading", { name: "Usuarios", level: 1 }),
     ).toBeInTheDocument();
 
-    await screen.findByText("Admin User");
-
-    expect(usersApi.getAll).toHaveBeenCalled();
+    expect(await screen.findByText("Admin User")).toBeInTheDocument();
+    expect(usersApi.getAll).toHaveBeenCalledTimes(1);
     expect(screen.getByText("admin@gaudeix.com")).toBeInTheDocument();
   });
 
-  it("can delete a user", async () => {
+  it("deletes a user and refetches list", async () => {
     (usersApi.delete as Mock).mockResolvedValue({});
 
     render(<UsersPage />);
+    expect(await screen.findByText("Admin User")).toBeInTheDocument();
 
-    await waitFor(() => {
-      expect(screen.getByText("Admin User")).toBeInTheDocument();
-    });
-
-    // Find the delete button for the first user
     const deleteButtons = screen.getAllByRole("button", { name: /eliminar/i });
-    const deleteBtn = deleteButtons[0];
+    await userEvent.click(deleteButtons[0]);
 
-    // Click delete button to open AlertDialog
-    fireEvent.click(deleteBtn);
-
-    // Wait for confirmation dialog to appear
-    await waitFor(() => {
-      expect(screen.getByText(/¿Estás seguro/i)).toBeInTheDocument();
+    const confirmButton = await screen.findByRole("button", {
+      name: /^Eliminar$/,
     });
+    await userEvent.click(confirmButton);
 
-    // Find and click the confirmation button by its text content
-    const confirmButton = screen.getByRole("button", { name: /^Eliminar$/ });
-    fireEvent.click(confirmButton);
-
-    // Should call delete API
     await waitFor(() => {
       expect(usersApi.delete).toHaveBeenCalledWith(1);
-    });
-
-    // Should refetch users
-    await waitFor(() => {
       expect(usersApi.getAll).toHaveBeenCalledTimes(2);
     });
   });

--- a/backoffice/src/layouts/dashboard/DashboardLayout.test.tsx
+++ b/backoffice/src/layouts/dashboard/DashboardLayout.test.tsx
@@ -1,21 +1,19 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { render, screen } from "@/tests/test-utils";
 import DashboardLayout from "@/layouts/dashboard/DashboardLayout";
 
 describe("DashboardLayout", () => {
-  it("renders sidebar with navigation", () => {
+  it("renders sidebar navigation links", () => {
     render(<DashboardLayout />);
 
-    expect(screen.getByText("Resumen")).toBeInTheDocument();
-    expect(screen.getByText("Usuarios")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /resumen/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /usuarios/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /media/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /eventos/i })).toBeInTheDocument();
   });
 
-  it("renders header", () => {
+  it("renders the dashboard header branding", () => {
     render(<DashboardLayout />);
-    // Header might not show logout button directly if user is not logged in or menu closed
-    // but header should be present
-    expect(screen.getByText(/Gaudeix/i)).toBeInTheDocument();
+    expect(screen.getByText(/gaudeix/i)).toBeInTheDocument();
   });
 });

--- a/backoffice/src/setupTests.ts
+++ b/backoffice/src/setupTests.ts
@@ -1,1 +1,9 @@
 import "@testing-library/jest-dom";
+import { cleanup } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});

--- a/backoffice/src/tests/fixtures/crudData.ts
+++ b/backoffice/src/tests/fixtures/crudData.ts
@@ -1,0 +1,49 @@
+export const mockUsers = [
+  {
+    id: 1,
+    username: "admin",
+    email: "admin@gaudeix.com",
+    name: "Admin User",
+    is_staff: true,
+    is_active: true,
+    date_joined: "2023-01-01T00:00:00Z",
+  },
+  {
+    id: 2,
+    username: "user",
+    email: "user@gaudeix.com",
+    name: "Regular User",
+    is_staff: false,
+    is_active: true,
+    date_joined: "2023-01-02T00:00:00Z",
+  },
+] as const;
+
+export const mockSocialLinks = [
+  {
+    id: 1,
+    name: "Facebook",
+    url: "https://facebook.com",
+    icon_class: "fa-brands fa-facebook",
+    color: "#3b5998",
+    available_in_ca: true,
+    available_in_es: true,
+    available_in_en: true,
+    available_in_fr: false,
+    order: 1,
+    is_active: true,
+  },
+  {
+    id: 2,
+    name: "Instagram",
+    url: "https://instagram.com",
+    icon_class: "fa-brands fa-instagram",
+    color: "#E1306C",
+    available_in_ca: true,
+    available_in_es: true,
+    available_in_en: true,
+    available_in_fr: false,
+    order: 2,
+    is_active: false,
+  },
+] as const;

--- a/backoffice/src/tests/test-utils.tsx
+++ b/backoffice/src/tests/test-utils.tsx
@@ -1,23 +1,45 @@
-import { ReactElement } from "react";
+import { ReactElement, ReactNode } from "react";
 import { render, RenderOptions } from "@testing-library/react";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter, MemoryRouter } from "react-router-dom";
 import { AppProviders } from "@/app/providers/AppProviders";
 
-/**
- * Custom render function that wraps components with all necessary providers
- * Use this instead of RTL's render in tests
- */
+type RouterMode =
+  | { type?: "browser" }
+  | { type: "memory"; initialEntries?: string[] };
+
+type CustomRenderOptions = Omit<RenderOptions, "wrapper"> & {
+  router?: RouterMode;
+};
+
+function Providers({ children }: { children: ReactNode }) {
+  return <AppProviders>{children}</AppProviders>;
+}
+
 function customRender(
   ui: ReactElement,
-  options?: Omit<RenderOptions, "wrapper">,
+  options?: CustomRenderOptions,
 ): ReturnType<typeof render> {
-  return render(ui, {
-    wrapper: ({ children }) => (
+  const { router, ...renderOptions } = options ?? {};
+
+  const Wrapper = ({ children }: { children: ReactNode }) => {
+    if (router?.type === "memory") {
+      return (
+        <MemoryRouter initialEntries={router.initialEntries}>
+          <Providers>{children}</Providers>
+        </MemoryRouter>
+      );
+    }
+
+    return (
       <BrowserRouter>
-        <AppProviders>{children}</AppProviders>
+        <Providers>{children}</Providers>
       </BrowserRouter>
-    ),
-    ...options,
+    );
+  };
+
+  return render(ui, {
+    wrapper: Wrapper,
+    ...renderOptions,
   });
 }
 


### PR DESCRIPTION
### Motivation
- Homogeneizar y robustecer la suite de tests del backoffice para mejorar consistencia, reducir fragilidad en selectores y facilitar reutilización de fixtures sin tocar comportamiento funcional.
- Evitar patrones mixtos de render/mocks entre tests y asegurar limpieza de estado entre cada caso para reducir falsos positivos/negativos.

### Description
- Añadí un `@/tests/test-utils` con un `render` centralizado que inyecta `AppProviders` y soporta `BrowserRouter` o `MemoryRouter` según opción, para un patrón de render único en todas las pruebas.
- Centralicé la limpieza en `setupTests.ts` con `cleanup`, `vi.clearAllMocks()` y `vi.restoreAllMocks()` en `afterEach` para aislar tests automáticamente.
- Extraje fixtures reutilizables en `backoffice/src/tests/fixtures/crudData.ts` y actualicé múltiples tests para consumirlos y eliminar duplicación de mocks de datos.
- Refactoricé múltiples tests (auth, users, social, routes, festes, events, landing, notifications, App, PageHeader, DashboardLayout) para usar el helper común, queries semánticas (`getByRole`/`findByText`) y `userEvent` en flujos interactivos; reemplacé tests “sanity” débiles por aserciones de flujo (ej. EventDates).

### Testing
- Ejecuté `npm test --prefix backoffice` y la suite pasó: all test files passing (48 tests passed).
- Ejecuté `npm run type-check --prefix backoffice` y `tsc --noEmit` devolvió éxito (type-check OK).
- Intenté `npm run lint --prefix backoffice` pero falló porque no existe el script `lint` en `backoffice/package.json` (documentado como nota pendiente).
- Quedaron advertencias de runtime en la salida de tests (warnings `act(...)` y advertencias de tiptap por extensiones duplicadas) que no provocaron fallos pero son puntos a limpiar en un trabajo futuro.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a76943e4e0832799e3e5a97583183b)