### PR TITLE
fix(backoffice): sync Select labels with async options and align dialog behavior

### DIFF
--- a/backoffice/src/components/ui/alert-dialog.tsx
+++ b/backoffice/src/components/ui/alert-dialog.tsx
@@ -2,6 +2,7 @@ import {
   createContext,
   useContext,
   useState,
+  useEffect,
   forwardRef,
   ReactNode,
   HTMLAttributes,
@@ -32,9 +33,7 @@ export function AlertDialog({
   const open = isControlled ? controlledOpen : internalOpen;
 
   const setOpen = (newOpen: boolean) => {
-    if (!isControlled) {
-      setInternalOpen(newOpen);
-    }
+    if (!isControlled) setInternalOpen(newOpen);
     onOpenChange?.(newOpen);
   };
 
@@ -79,20 +78,28 @@ export const AlertDialogContent = forwardRef<
   if (!context)
     throw new Error("AlertDialogContent must be used within AlertDialog");
 
+  useEffect(() => {
+    if (!context.open) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") context.setOpen(false);
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [context]);
+
   if (!context.open) return null;
 
   return (
-    <div className="relative z-50">
-      {/* Backdrop - Increased blur and darkness */}
+    <div className="relative z-50" role="alertdialog" aria-modal="true">
       <div
         className="fixed inset-0 bg-gray-950/60 backdrop-blur-[4px] transition-opacity animate-in fade-in duration-300"
         onClick={() => context.setOpen(false)}
       />
 
-      {/* Scroll Container */}
       <div className="fixed inset-0 z-50 overflow-y-auto">
-        <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-0">
-          {/* Modal Panel - Premium styles: rounded-2xl, deep shadow */}
+        <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-6">
           <div
             ref={ref}
             className={`relative w-full max-w-lg transform overflow-hidden rounded-2xl border border-gray-200 bg-white p-6 text-left shadow-2xl transition-all animate-in fade-in zoom-in-95 slide-in-from-bottom-4 duration-300 dark:border-gray-800 dark:bg-gray-900 ${className || ""}`}

--- a/backoffice/src/components/ui/dialog.test.tsx
+++ b/backoffice/src/components/ui/dialog.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "./dialog";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "./alert-dialog";
+
+describe("Dialog", () => {
+  it("opens by trigger and closes by backdrop click", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Dialog>
+        <DialogTrigger>Abrir</DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Modal</DialogTitle>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Abrir" }));
+    expect(screen.getByText("Modal")).toBeInTheDocument();
+
+    await user.click(document.querySelector(".fixed.inset-0") as Element);
+    expect(screen.queryByText("Modal")).not.toBeInTheDocument();
+  });
+
+  it("closes with Escape key", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Dialog>
+        <DialogTrigger>Abrir Escape</DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Modal Escape</DialogTitle>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Abrir Escape" }));
+    expect(screen.getByText("Modal Escape")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByText("Modal Escape")).not.toBeInTheDocument();
+  });
+});
+
+describe("AlertDialog", () => {
+  it("opens and closes with Escape", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <AlertDialog>
+        <AlertDialogTrigger>Eliminar</AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirmación</AlertDialogTitle>
+          </AlertDialogHeader>
+        </AlertDialogContent>
+      </AlertDialog>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Eliminar" }));
+    expect(screen.getByText("Confirmación")).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByText("Confirmación")).not.toBeInTheDocument();
+  });
+});

--- a/backoffice/src/components/ui/dialog.tsx
+++ b/backoffice/src/components/ui/dialog.tsx
@@ -2,6 +2,7 @@ import {
   createContext,
   useContext,
   useState,
+  useEffect,
   forwardRef,
   ReactNode,
   HTMLAttributes,
@@ -31,9 +32,7 @@ export function Dialog({
   const open = isControlled ? controlledOpen : internalOpen;
 
   const setOpen = (newOpen: boolean) => {
-    if (!isControlled) {
-      setInternalOpen(newOpen);
-    }
+    if (!isControlled) setInternalOpen(newOpen);
     onOpenChange?.(newOpen);
   };
 
@@ -73,33 +72,38 @@ export const DialogContent = forwardRef<
   const context = useContext(DialogContext);
   if (!context) throw new Error("DialogContent must be used within Dialog");
 
+  useEffect(() => {
+    if (!context.open) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") context.setOpen(false);
+    };
+
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [context]);
+
   if (!context.open) return null;
 
   return (
-    <div className="relative z-50">
-      {/* Backdrop - Increased blur and darkness for better focus */}
+    <div className="relative z-50" role="dialog" aria-modal="true">
       <div
         className="fixed inset-0 bg-gray-950/60 backdrop-blur-[4px] transition-all animate-in fade-in duration-300"
         aria-hidden="true"
+        onClick={() => context.setOpen(false)}
       />
 
-      {/* Scroll Container - This handles clicking outside the modal panel */}
       <div
         className="fixed inset-0 z-50 overflow-y-auto"
         onClick={() => context.setOpen(false)}
       >
         <div className="flex min-h-full items-center justify-center p-4 text-center sm:p-6">
-          {/* Modal Panel - Premium styles: rounded-2xl, deep shadow, subtle border */}
           <div
             ref={ref}
             className={`relative w-full max-w-2xl transform overflow-hidden rounded-2xl border border-gray-200 bg-white text-left shadow-2xl transition-all animate-in fade-in zoom-in-95 slide-in-from-bottom-4 duration-300 dark:border-gray-800 dark:bg-gray-900 ${className || ""}`}
-            onClick={(e) => {
-              // VERY IMPORTANT: Stop propagation so clicks inside the modal don't close it
-              e.stopPropagation();
-            }}
+            onClick={(e) => e.stopPropagation()}
             {...props}
           >
-            {/* Close Button - Floating circular button */}
             <button
               type="button"
               className="absolute right-4 top-4 z-10 inline-flex h-8 w-8 items-center justify-center rounded-full bg-gray-50 text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:bg-gray-800 dark:text-gray-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"

--- a/backoffice/src/components/ui/select.test.tsx
+++ b/backoffice/src/components/ui/select.test.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./select";
+
+describe("Select", () => {
+  it("renders DB value label when options arrive asynchronously", async () => {
+    function AsyncOptionsSelect() {
+      const [options, setOptions] = useState<
+        Array<{ id: number; name: string }>
+      >([]);
+      const [value] = useState<number>(2);
+
+      useEffect(() => {
+        const timer = setTimeout(() => {
+          setOptions([
+            { id: 1, name: "Categoria A" },
+            { id: 2, name: "Categoria B" },
+          ]);
+        }, 0);
+
+        return () => clearTimeout(timer);
+      }, []);
+
+      return (
+        <Select value={value}>
+          <SelectTrigger>
+            <SelectValue placeholder="Selecciona" />
+          </SelectTrigger>
+          <SelectContent>
+            {options.map((option) => (
+              <SelectItem key={option.id} value={String(option.id)}>
+                {option.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      );
+    }
+
+    render(<AsyncOptionsSelect />);
+
+    expect(screen.getByText("Selecciona")).toBeInTheDocument();
+    expect(await screen.findByText("Categoria B")).toBeInTheDocument();
+  });
+
+  it("supports uncontrolled mode and updates label on selection", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <Select defaultValue="a">
+        <SelectTrigger>
+          <SelectValue placeholder="Selecciona" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="a">Opción A</SelectItem>
+          <SelectItem value="b">Opción B</SelectItem>
+        </SelectContent>
+      </Select>,
+    );
+
+    expect(screen.getByText("Opción A")).toBeInTheDocument();
+    const trigger = screen.getByRole("button");
+    await user.click(trigger);
+    await user.click(screen.getAllByText("Opción B")[0]);
+    expect(trigger).toHaveTextContent("Opción B");
+  });
+});

--- a/backoffice/src/components/ui/select.tsx
+++ b/backoffice/src/components/ui/select.tsx
@@ -4,6 +4,8 @@ import {
   useState,
   useRef,
   useEffect,
+  useMemo,
+  useCallback,
   forwardRef,
   ReactNode,
   HTMLAttributes,
@@ -23,11 +25,18 @@ interface SelectContextValue {
 const SelectContext = createContext<SelectContextValue | undefined>(undefined);
 
 interface SelectProps {
-  value?: string;
-  defaultValue?: string;
+  value?: string | number | null;
+  defaultValue?: string | number | null;
   onValueChange?: (value: string) => void;
   children: ReactNode;
 }
+
+const normalizeSelectValue = (
+  value: string | number | null | undefined,
+): string | undefined => {
+  if (value === null || value === undefined) return undefined;
+  return String(value);
+};
 
 export const Select = ({
   value: controlledValue,
@@ -35,40 +44,60 @@ export const Select = ({
   onValueChange,
   children,
 }: SelectProps) => {
-  const [internalValue, setInternalValue] = useState(defaultValue);
+  const [internalValue, setInternalValue] = useState<string | undefined>(() =>
+    normalizeSelectValue(defaultValue),
+  );
   const [open, setOpen] = useState(false);
-  const labelMap = useRef(new Map<string, ReactNode>()).current;
+  const labelMapRef = useRef(new Map<string, ReactNode>());
+  const [, setLabelVersion] = useState(0);
   const rootRef = useRef<HTMLDivElement>(null);
-  const [, forceUpdate] = useState(0); // Force re-render when labels update
+  const isControlled = controlledValue !== undefined;
+  const value = isControlled
+    ? normalizeSelectValue(controlledValue)
+    : internalValue;
 
-  const value = controlledValue !== undefined ? controlledValue : internalValue;
+  useEffect(() => {
+    if (!isControlled) return;
+    setInternalValue(normalizeSelectValue(controlledValue));
+  }, [controlledValue, isControlled]);
 
-  const handleValueChange = (newValue: string) => {
-    setInternalValue(newValue);
-    onValueChange?.(newValue);
-    setOpen(false);
-  };
+  const handleValueChange = useCallback(
+    (newValue: string) => {
+      if (!isControlled) {
+        setInternalValue(newValue);
+      }
+      onValueChange?.(newValue);
+      setOpen(false);
+    },
+    [isControlled, onValueChange],
+  );
 
-  const registerLabel = (val: string, label: ReactNode) => {
-    if (labelMap.get(val) !== label) {
-      labelMap.set(val, label);
-      // Debounce updates slightly or allow initial render
-      setTimeout(() => forceUpdate((n) => n + 1), 0);
+  const registerLabel = useCallback((val: string, label: ReactNode) => {
+    const normalizedValue = normalizeSelectValue(val);
+    if (!normalizedValue) return;
+
+    const currentLabel = labelMapRef.current.get(normalizedValue);
+    if (currentLabel !== label) {
+      labelMapRef.current.set(normalizedValue, label);
+      setLabelVersion((n) => n + 1);
     }
-  };
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      value,
+      onValueChange: handleValueChange,
+      open,
+      setOpen,
+      labelMap: labelMapRef.current,
+      registerLabel,
+      rootRef,
+    }),
+    [value, handleValueChange, open, registerLabel],
+  );
 
   return (
-    <SelectContext.Provider
-      value={{
-        value,
-        onValueChange: handleValueChange,
-        open,
-        setOpen,
-        labelMap,
-        registerLabel,
-        rootRef,
-      }}
-    >
+    <SelectContext.Provider value={contextValue}>
       <div ref={rootRef} className="relative w-full">
         {children}
       </div>
@@ -109,7 +138,7 @@ export const SelectValue = forwardRef<
 
   const selectedLabel =
     context.value !== undefined && context.value !== null
-      ? context.labelMap.get(context.value)
+      ? context.labelMap.get(String(context.value))
       : null;
 
   return (
@@ -150,14 +179,14 @@ export const SelectContent = forwardRef<
     };
   }, [context]);
 
-  if (!context?.open) return null;
-
   return (
     <div
       ref={ref}
-      className={`absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border border-gray-200 bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white sm:text-sm animate-in fade-in zoom-in-95 duration-100 ${
-        className || ""
-      }`}
+      className={`absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md border border-gray-200 bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white sm:text-sm ${
+        context?.open
+          ? "animate-in fade-in zoom-in-95 duration-100"
+          : "hidden pointer-events-none"
+      } ${className || ""}`}
       {...props}
     >
       {children}

--- a/backoffice/src/features/events/components/EventDialog.tsx
+++ b/backoffice/src/features/events/components/EventDialog.tsx
@@ -407,11 +407,6 @@ export function EventDialog({ open, onOpenChange, onSubmit, event }: Props) {
     [images, form.featured_media_id],
   );
 
-  const selectedCategory = useMemo(
-    () => categories.find((cat) => cat.id === form.category_id),
-    [categories, form.category_id],
-  );
-
   const selectedAttachments = useMemo(
     () => documents.filter((doc) => form.attachments_ids?.includes(doc.id)),
     [documents, form.attachments_ids],
@@ -543,9 +538,7 @@ export function EventDialog({ open, onOpenChange, onSubmit, event }: Props) {
                     }
                   >
                     <SelectTrigger id="category_id">
-                      <SelectValue placeholder="Selecciona una categoría">
-                        {selectedCategory?.nombre}
-                      </SelectValue>
+                      <SelectValue placeholder="Selecciona una categoría" />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="">Por defecto</SelectItem>

--- a/backoffice/src/features/llm-settings/pages/LLMSettingsPage.tsx
+++ b/backoffice/src/features/llm-settings/pages/LLMSettingsPage.tsx
@@ -349,12 +349,7 @@ export function LLMSettingsPage() {
                       onValueChange={(v) => onChange("provider", v)}
                     >
                       <SelectTrigger>
-                        <SelectValue placeholder="Selecciona un provider">
-                          {
-                            PROVIDERS.find((p) => p.value === form.provider)
-                              ?.label
-                          }
-                        </SelectValue>
+                        <SelectValue placeholder="Selecciona un provider" />
                       </SelectTrigger>
                       <SelectContent>
                         {PROVIDERS.map((p) => (
@@ -373,13 +368,7 @@ export function LLMSettingsPage() {
                       onValueChange={(v) => onChange("model_name", v)}
                     >
                       <SelectTrigger>
-                        <SelectValue placeholder="Selecciona un modelo">
-                          {
-                            modelOptions.find(
-                              (m) => m.value === form.model_name,
-                            )?.label
-                          }
-                        </SelectValue>
+                        <SelectValue placeholder="Selecciona un modelo" />
                       </SelectTrigger>
                       <SelectContent>
                         {modelOptions.map((m) => (

--- a/backoffice/src/features/news/components/NewsDialog.tsx
+++ b/backoffice/src/features/news/components/NewsDialog.tsx
@@ -207,11 +207,6 @@ export function NewsDialog({ open, onOpenChange, onSubmit, news }: Props) {
     [images, form.featured_media_id],
   );
 
-  const selectedCategory = useMemo(
-    () => categories.find((cat) => cat.id === form.category_id),
-    [categories, form.category_id],
-  );
-
   const selectedAttachments = useMemo(
     () => documents.filter((doc) => form.attachments_ids?.includes(doc.id)),
     [documents, form.attachments_ids],
@@ -239,9 +234,7 @@ export function NewsDialog({ open, onOpenChange, onSubmit, news }: Props) {
                 }
               >
                 <SelectTrigger id="category_id">
-                  <SelectValue placeholder="Selecciona una categoría">
-                    {selectedCategory?.nombre}
-                  </SelectValue>
+                  <SelectValue placeholder="Selecciona una categoría" />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="">Sin categoría</SelectItem>

--- a/backoffice/src/features/scraper/components/StartScrapeDialog.tsx
+++ b/backoffice/src/features/scraper/components/StartScrapeDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Play, Loader2 } from "lucide-react";
 import { ScraperSource } from "../types";
 import {
@@ -37,10 +37,19 @@ export function StartScrapeDialog({
   const [maxPages, setMaxPages] = useState("5");
   const [loading, setLoading] = useState(false);
 
-  // Set default source when sources load
-  if (!selectedSource && sources.length > 0) {
-    setSelectedSource(sources[0].slug);
-  }
+  useEffect(() => {
+    if (!open) return;
+    if (sources.length === 0) {
+      setSelectedSource("");
+      return;
+    }
+
+    setSelectedSource((prev) =>
+      prev && sources.some((source) => source.slug === prev)
+        ? prev
+        : sources[0].slug,
+    );
+  }, [open, sources]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
### Motivation
- Fixar bug donde un `Select` controlado muestra el placeholder cuando el valor viene de la DB pero las opciones se cargan de forma asíncrona porque los `SelectItem` nunca habían registrado su label mientras el dropdown estaba desmontado.
- Unificar la experiencia y accesibilidad de los modales (`Dialog` / `AlertDialog`) para garantizar cierre por overlay, Escape y estructura consistente de panel/header/footer.
- Evitar desincronizaciones de tipos y de hidratación entre `string|number|null` en valores de formularios y el `SelectValue` mostrado.

### Description
- Reimplementado `Select` para normalizar `value`/`defaultValue` (`string | number | null` → `string`), soportar controlled/uncontrolled de forma robusta y exponer `registerLabel` con un mapa interno para resolver labels cuando las opciones llegan tarde; `SelectContent` ahora se mantiene montado (oculto cuando está cerrado) para permitir el registro de labels incluso antes de abrir el dropdown.
- Armonizados `Dialog` y `AlertDialog` para comportamiento consistente (overlay click cierra, Escape cierra, `role`/`aria-modal` añadidos, y espaciado/panel uniformes) y handlers de teclado centralizados en `useEffect`.
- Actualizados consumers que inyectaban manualmente el label dentro de `SelectValue` (por ejemplo `EventDialog`, `NewsDialog`, `LLMSettingsPage`) para confiar en la resolución automática del label registrado por `SelectItem` y corregir riesgos de tipo/async.
- Corregido `StartScrapeDialog` para establecer `selectedSource` en `useEffect` dependiendo de `open` y `sources` en lugar de llamar a `setState` durante render; añadidos tests unitarios para el regresión del `Select` y flujos de apertura/cierre de modales.
- Archivos principales tocados: `backoffice/src/components/ui/select.tsx`, `backoffice/src/components/ui/dialog.tsx`, `backoffice/src/components/ui/alert-dialog.tsx`, `backoffice/src/features/events/components/EventDialog.tsx`, `backoffice/src/features/news/components/NewsDialog.tsx`, `backoffice/src/features/llm-settings/pages/LLMSettingsPage.tsx`, `backoffice/src/features/scraper/components/StartScrapeDialog.tsx`, y tests nuevos en `backoffice/src/components/ui/select.test.tsx` y `backoffice/src/components/ui/dialog.test.tsx`.

### Testing
- Ejecutado `npm test --prefix backoffice` y la suite de backoffice pasó (todos los tests relacionados incluidos los nuevos de `select.test.tsx` y `dialog.test.tsx` pasaron).
- Ejecutado `npm run type-check --prefix backoffice` y `tsc --noEmit` no devolvió errores.
- Ejecutado `npm run lint --prefix backoffice` y falló porque no existe el script `lint` en `backoffice/package.json` (deuda de scripts fuera del alcance de este cambio).
- Añadidos tests automáticos que cubren la regresión real: `Select` con valor desde DB + opciones asíncronas que resuelve correctamente el label, y tests de apertura/cierre de `Dialog`/`AlertDialog` (trigger, backdrop click, Escape).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a76948d2008327adc16405d2343d86)