### PR TITLE
feat(backoffice): refresh visual style with municipal corporate tone

### DIFF
--- a/UX/backoffice-visual-refresh.md
+++ b/UX/backoffice-visual-refresh.md
@@ -1,0 +1,65 @@
+# Backoffice Visual Refresh (Municipal / Corporativo)
+
+## 1) Guía conceptual (principios)
+
+- Priorizar claridad institucional: superficies limpias, jerarquía tipográfica y bloques bien delimitados.
+- Comunicar confianza y estabilidad con paleta sobria (azules cívicos, verdes suaves y neutros).
+- Asegurar lectura rápida en operaciones diarias: contraste alto, densidad media y microcopys visibles.
+- Mantener familiaridad funcional: misma arquitectura visual y mismos componentes; solo refinamiento estético.
+- Reducir ruido visual: menos efectos “llamativos”, transiciones discretas y estados consistentes.
+- Reforzar consistencia: iconografía Lucide homogénea, radios y sombras sistematizados.
+- Mejorar percepción de calidad en listados/formularios con contenedores, tablas y filtros más estructurados.
+
+## 2) Propuesta de tokens
+
+- **Color**
+  - `primary` (azul institucional): de `#f0f6fb` a `#152739`.
+  - `secondary` (verde cívico suave): de `#f1f7f4` a `#243f32`.
+  - Neutros operativos: base en `slate` para fondos, bordes y textos.
+- **Tipografía**
+  - `--font-sans`: `Source Sans 3` (fallback `Inter`, `system-ui`, `sans-serif`).
+  - Pesos recomendados: 400/500/600/700.
+- **Radios**
+  - Contenedores principales: `rounded-xl`.
+  - Controles y acciones: `rounded-md`.
+- **Sombras**
+  - Estado base: `shadow-sm`.
+  - Elevación en hover: `shadow-md` muy contenida.
+- **Spacing**
+  - Ritmo 4/6/8 en separaciones de secciones.
+  - Tablas y cards con paddings de 4-6 para legibilidad.
+
+## 3) Aplicación en pantallas clave
+
+- **Home / Dashboard**
+  - KPI cards con tono institucional y hover sutil.
+  - Quick actions unificadas (mismo lenguaje visual y jerarquía).
+  - Actividad reciente con timeline más limpio y contrastado.
+- **Listado de contenidos (Noticias)**
+  - Filtros en panel contenedor sobrio (borde + fondo blanco).
+  - Tabla con cabecera neutra institucional y estados publicados/borrador más legibles.
+  - Acciones de fila con feedback suave y color semántico controlado.
+- **Detalle/Formulario (Noticias Dialog)**
+  - Superficie del modal y bloques internos con mejor separación visual.
+  - Inputs/select/toggles con neutros de mayor contraste.
+  - Tabs y paneles multimedia con estructura más corporativa.
+
+## 4) Antes / Después y rationale
+
+- **Antes:** look más “producto startup” (acentos vivos, hover más expresivos, mezcla cromática).  
+  **Después:** look administrativo institucional (neutros + azul/verde cívico), más sobrio y realista.
+- **Antes:** jerarquía visual irregular entre filtros, tablas y cards.  
+  **Después:** contenedores, bordes y títulos consistentes entre módulos.
+- **Antes:** algunos controles con contraste justo en estados intermedios.  
+  **Después:** contraste reforzado en textos/bordes/estados para uso diario (AA orientativo).
+- **Antes:** microinteracciones más decorativas.  
+  **Después:** interacciones discretas enfocadas en feedback, no en protagonismo.
+
+## 5) Checklist no-breaking
+
+- [x] Sin cambios en lógica de negocio.
+- [x] Sin cambios en rutas ni navegación.
+- [x] Sin cambios en API client ni contratos.
+- [x] Sin cambios en permisos/autenticación.
+- [x] Sin cambios de arquitectura ni estructura de features.
+- [x] Sin introducir librerías nuevas de iconos (se mantiene Lucide).

--- a/backoffice/src/components/common/StatCard.tsx
+++ b/backoffice/src/components/common/StatCard.tsx
@@ -16,35 +16,38 @@ export function StatCard({
   className,
 }: StatCardProps) {
   const toneStyles = {
-    neutral: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300",
-    primary: "bg-primary-50 text-primary-600 dark:bg-primary-500/10 dark:text-primary-400",
-    success: "bg-green-50 text-green-600 dark:bg-green-500/10 dark:text-green-400",
-    warning: "bg-amber-50 text-amber-600 dark:bg-amber-500/10 dark:text-amber-400",
-    info: "bg-blue-50 text-blue-600 dark:bg-blue-500/10 dark:text-blue-400",
+    neutral:
+      "bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300",
+    primary:
+      "bg-primary-50 text-primary-700 dark:bg-primary-500/15 dark:text-primary-300",
+    success:
+      "bg-secondary-50 text-secondary-700 dark:bg-secondary-500/15 dark:text-secondary-300",
+    warning:
+      "bg-amber-50 text-amber-700 dark:bg-amber-500/10 dark:text-amber-300",
+    info: "bg-sky-50 text-sky-700 dark:bg-sky-500/10 dark:text-sky-300",
   };
 
   return (
     <div
-      className={`group relative overflow-hidden rounded-xl border border-gray-100 bg-white p-6 shadow-sm transition-all hover:-translate-y-1 hover:shadow-md dark:border-gray-800 dark:bg-gray-900 ${className || ""}`}
+      className={`group relative overflow-hidden rounded-xl border border-slate-200 bg-white p-6 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md dark:border-slate-800 dark:bg-slate-900 ${className || ""}`}
     >
       <div className="flex items-start justify-between">
-        <div className="space-y-1">
-          <p className="text-sm font-medium text-gray-500 dark:text-gray-400">{label}</p>
-          <div className="flex items-baseline gap-2">
-            <h3 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
-              {value}
-            </h3>
-          </div>
+        <div className="space-y-1.5">
+          <p className="text-sm font-semibold text-slate-600 dark:text-slate-300">
+            {label}
+          </p>
+          <h3 className="text-3xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">
+            {value}
+          </h3>
         </div>
         <div
-          className={`flex h-12 w-12 items-center justify-center rounded-xl ring-1 ring-inset ring-black/5 transition-transform group-hover:scale-110 dark:ring-white/5 ${toneStyles[tone]}`}
+          className={`flex h-11 w-11 items-center justify-center rounded-lg ring-1 ring-inset ring-black/5 transition-transform duration-200 group-hover:scale-105 dark:ring-white/10 ${toneStyles[tone]}`}
         >
-          <Icon className="h-6 w-6" strokeWidth={2.5} />
+          <Icon className="h-5 w-5" strokeWidth={2.25} />
         </div>
       </div>
-      
-      {/* Decorative background shape - adjusted for dark mode visibility */}
-      <div className="absolute -right-6 -top-6 h-24 w-24 rounded-full bg-gray-50 opacity-0 transition-opacity group-hover:opacity-100 dark:bg-gray-800/30 pointer-events-none" />
+
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-0.5 bg-gradient-to-r from-primary-500/0 via-primary-500/45 to-primary-500/0 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
     </div>
   );
 }

--- a/backoffice/src/features/dashboard/pages/DashboardHome.tsx
+++ b/backoffice/src/features/dashboard/pages/DashboardHome.tsx
@@ -37,7 +37,7 @@ export function DashboardHome() {
   if (loading) {
     return (
       <div className="flex h-64 items-center justify-center">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary-200 border-t-primary-600"></div>
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary-200 border-t-primary-700"></div>
       </div>
     );
   }
@@ -49,59 +49,50 @@ export function DashboardHome() {
     icon: Icon,
     title,
     desc,
-    color,
-    ringColor,
   }: {
     to: string;
     icon: React.ComponentType<{ className?: string }>;
     title: string;
     desc: string;
-    color: string;
-    ringColor?: string;
   }) => (
     <Link
       to={to}
-      className={`group relative flex flex-col justify-between overflow-hidden rounded-xl border border-gray-100 bg-white p-6 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg hover:ring-2 ${ringColor || "hover:ring-primary-500/20"} dark:border-gray-800 dark:bg-gray-800`}
+      className="group relative flex min-h-40 flex-col justify-between overflow-hidden rounded-xl border border-slate-200 bg-white p-5 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-primary-200 hover:shadow-md dark:border-slate-800 dark:bg-slate-900"
     >
-      <div
-        className={`mb-4 inline-flex h-14 w-14 items-center justify-center rounded-xl ${color} shadow-sm transition-transform group-hover:scale-110 group-hover:rotate-3`}
-      >
-        <Icon className="h-7 w-7 text-white" />
+      <div className="mb-4 inline-flex h-11 w-11 items-center justify-center rounded-lg bg-primary-50 text-primary-700 ring-1 ring-primary-100 transition-colors group-hover:bg-primary-100 dark:bg-primary-950/40 dark:text-primary-300 dark:ring-primary-900">
+        <Icon className="h-5 w-5" />
       </div>
       <div>
-        <h3 className="mb-2 text-lg font-bold text-gray-900 dark:text-white group-hover:text-primary-600 dark:group-hover:text-primary-400 transition-colors">
+        <h3 className="mb-2 text-base font-semibold text-slate-900 transition-colors group-hover:text-primary-800 dark:text-slate-100 dark:group-hover:text-primary-300">
           {title}
         </h3>
-        <p className="text-sm font-medium text-gray-500 dark:text-gray-400 group-hover:text-gray-700 dark:group-hover:text-gray-300 transition-colors">
-          {desc}
-        </p>
+        <p className="text-sm text-slate-600 dark:text-slate-400">{desc}</p>
       </div>
-      <div className="absolute right-5 top-5 opacity-0 -translate-x-2 transition-all group-hover:opacity-100 group-hover:translate-x-0">
-        <ArrowRight className="h-5 w-5 text-gray-400" />
+      <div className="absolute right-4 top-4 opacity-0 transition-opacity group-hover:opacity-100">
+        <ArrowRight className="h-4 w-4 text-primary-500" />
       </div>
     </Link>
   );
 
   return (
-    <div className="container flex min-h-[calc(100vh-4rem)] flex-col items-center justify-center px-4 py-8 mx-auto animate-in fade-in duration-500">
-      <div className="w-full max-w-6xl space-y-8">
-        {/* Header */}
+    <div className="container mx-auto flex min-h-[calc(100vh-4rem)] max-w-6xl flex-col px-2 py-2 md:px-0">
+      <div className="w-full space-y-8">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
-            <h2 className="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+            <h2 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">
               Dashboard
             </h2>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">
               Resumen general de la plataforma Gaudeix
             </p>
           </div>
           <div className="flex items-center space-x-3">
-            <button className="inline-flex items-center justify-center rounded-lg bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 dark:bg-gray-800 dark:text-gray-200 dark:ring-gray-700 dark:hover:bg-gray-700">
+            <button className="inline-flex items-center justify-center rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800">
               Descargar Reporte
             </button>
             <Link
               to={ROUTES.EVENTS}
-              className="inline-flex items-center justify-center rounded-lg bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:bg-primary-600 dark:hover:bg-primary-700"
+              className="inline-flex items-center justify-center rounded-md bg-primary-700 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary-800 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
             >
               <Plus className="-ml-1 mr-2 h-4 w-4" />
               Nuevo Evento
@@ -109,8 +100,7 @@ export function DashboardHome() {
           </div>
         </div>
 
-        {/* KPI Cards */}
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-4">
           <StatCard
             label="Total Usuarios"
             value={stats?.totalUsers || 0}
@@ -138,9 +128,8 @@ export function DashboardHome() {
         </div>
 
         <div className="grid gap-8 lg:grid-cols-3">
-          {/* Quick Actions */}
-          <div className="lg:col-span-2 space-y-6">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+          <div className="space-y-4 lg:col-span-2">
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
               Accesos Rápidos
             </h3>
             <div className="grid gap-4 sm:grid-cols-2">
@@ -149,72 +138,63 @@ export function DashboardHome() {
                 icon={Calendar}
                 title="Gestionar Eventos"
                 desc="Crear, editar y moderar eventos del calendario."
-                color="bg-purple-600"
-                ringColor="hover:ring-purple-500/30"
               />
               <QuickAction
                 to={ROUTES.STATIC_PAGES}
                 icon={FileText}
                 title="Páginas Estáticas"
                 desc="Administrar contenido institucional y legal."
-                color="bg-blue-600"
-                ringColor="hover:ring-blue-500/30"
               />
               <QuickAction
                 to={ROUTES.USERS}
                 icon={Users}
                 title="Usuarios"
                 desc="Control de acceso y perfiles de usuarios."
-                color="bg-emerald-600"
-                ringColor="hover:ring-emerald-500/30"
               />
               <QuickAction
                 to={ROUTES.PLACES}
                 icon={MapPin}
                 title="Lugares"
                 desc="Directorio de puntos de interés y mapas."
-                color="bg-amber-600"
-                ringColor="hover:ring-amber-500/30"
               />
             </div>
           </div>
 
-          {/* Recent Activity */}
-          <div className="space-y-6">
+          <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
                 Actividad Reciente
               </h3>
               <Link
                 to="#"
-                className="text-sm font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400"
+                className="text-sm font-medium text-primary-700 hover:text-primary-800 dark:text-primary-300"
               >
                 Ver todo
               </Link>
             </div>
 
-            <div className="rounded-xl border border-gray-100 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-800">
+            <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
               {recentActivity.length === 0 ? (
                 <div className="flex flex-col items-center justify-center py-8 text-center">
-                  <div className="rounded-full bg-gray-50 p-3 dark:bg-gray-700/50">
-                    <Bell className="h-6 w-6 text-gray-400" />
+                  <div className="rounded-full bg-slate-100 p-3 dark:bg-slate-800">
+                    <Bell className="h-6 w-6 text-slate-500" />
                   </div>
-                  <p className="mt-3 text-sm text-gray-500 dark:text-gray-400">
+                  <p className="mt-3 text-sm text-slate-600 dark:text-slate-400">
                     No hay actividad reciente registrada.
                   </p>
                 </div>
               ) : (
-                <div className="relative border-l border-gray-200 dark:border-gray-700 ml-3 space-y-6">
+                <div className="relative ml-3 space-y-6 border-l border-slate-200 dark:border-slate-700">
                   {recentActivity.map((activity, idx) => (
                     <div
                       key={activity.id || idx}
                       className="mb-6 ml-6 last:mb-0"
                     >
-                      <span className="absolute -left-1.5 mt-1.5 h-3 w-3 rounded-full bg-gray-200 ring-4 ring-white dark:bg-gray-700 dark:ring-gray-800"></span>
-                      <p className="text-sm font-medium text-gray-900 dark:text-white">
+                      <span className="absolute -left-1.5 mt-1.5 h-3 w-3 rounded-full bg-primary-200 ring-4 ring-white dark:bg-primary-700 dark:ring-slate-900"></span>
+                      <p className="text-sm font-medium text-slate-900 dark:text-slate-100">
                         {activity.message}
                       </p>
-                      <time className="mb-1 text-xs font-normal text-gray-500 dark:text-gray-400">
+                      <time className="mb-1 text-xs font-normal text-slate-500 dark:text-slate-400">
                         {new Date(activity.timestamp).toLocaleDateString()}
                       </time>
                     </div>
@@ -225,7 +205,6 @@ export function DashboardHome() {
           </div>
         </div>
 
-        {/* Favorites KPI - Top 5 most favorited events */}
         <FavoritesKPI />
       </div>
     </div>

--- a/backoffice/src/features/news/components/NewsDialog.tsx
+++ b/backoffice/src/features/news/components/NewsDialog.tsx
@@ -214,7 +214,7 @@ export function NewsDialog({ open, onOpenChange, onSubmit, news }: Props) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-[860px] px-6">
+      <DialogContent className="max-w-[900px] border-slate-200 bg-white px-6 shadow-xl dark:border-slate-800 dark:bg-slate-900">
         <DialogHeader>
           <DialogTitle>{news ? "Editar noticia" : "Nueva noticia"}</DialogTitle>
         </DialogHeader>
@@ -259,13 +259,13 @@ export function NewsDialog({ open, onOpenChange, onSubmit, news }: Props) {
                     publish_date: e.target.value ? toIso(e.target.value) : null,
                   }))
                 }
-                className="bg-white dark:bg-gray-800"
+                className="border-slate-300 bg-white dark:border-slate-700 dark:bg-slate-950"
               />
             </div>
           </div>
 
           {/* Publication Settings */}
-          <div className="grid gap-6 md:grid-cols-2 p-4 border border-border rounded-xl bg-muted/10">
+          <div className="grid gap-6 rounded-xl border border-slate-200 bg-slate-50/70 p-4 md:grid-cols-2 dark:border-slate-800 dark:bg-slate-800/40">
             {/* Publicado */}
             <div className="flex flex-col gap-1.5">
               <label className="inline-flex items-center cursor-pointer">
@@ -280,8 +280,8 @@ export function NewsDialog({ open, onOpenChange, onSubmit, news }: Props) {
                     }))
                   }
                 />
-                <div className="relative w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary-100 dark:peer-focus:ring-primary-900 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-primary-600"></div>
-                <span className="select-none ms-3 text-sm font-medium text-gray-900 dark:text-gray-100">
+                <div className="relative w-9 h-5 bg-slate-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary-100 dark:peer-focus:ring-primary-900 rounded-full peer dark:bg-slate-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-slate-200 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-slate-500 peer-checked:bg-primary-600"></div>
+                <span className="select-none ms-3 text-sm font-medium text-slate-900 dark:text-slate-100">
                   Publicado
                 </span>
               </label>
@@ -304,8 +304,8 @@ export function NewsDialog({ open, onOpenChange, onSubmit, news }: Props) {
                     }))
                   }
                 />
-                <div className="relative w-9 h-5 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary-100 dark:peer-focus:ring-primary-900 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-gray-600 peer-checked:bg-primary-600"></div>
-                <span className="select-none ms-3 text-sm font-medium text-gray-900 dark:text-gray-100">
+                <div className="relative w-9 h-5 bg-slate-300 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-primary-100 dark:peer-focus:ring-primary-900 rounded-full peer dark:bg-slate-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-slate-200 after:border after:rounded-full after:h-4 after:w-4 after:transition-all dark:border-slate-500 peer-checked:bg-primary-600"></div>
+                <span className="select-none ms-3 text-sm font-medium text-slate-900 dark:text-slate-100">
                   Destacado
                 </span>
               </label>
@@ -317,7 +317,7 @@ export function NewsDialog({ open, onOpenChange, onSubmit, news }: Props) {
 
           {/* Translation Tabs */}
           <Tabs value={activeLang} onValueChange={setActiveLang}>
-            <TabsList className="grid w-full grid-cols-4">
+            <TabsList className="grid w-full grid-cols-4 rounded-md bg-slate-100 p-1 dark:bg-slate-800">
               {LANGUAGES.map((lang) => (
                 <TabsTrigger key={lang.code} value={lang.code}>
                   {lang.name}
@@ -382,7 +382,7 @@ export function NewsDialog({ open, onOpenChange, onSubmit, news }: Props) {
           {/* Media Section */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {/* Featured Image Selection */}
-            <div className="space-y-3 rounded-xl border border-border/60 bg-muted/30 p-4 shadow-sm">
+            <div className="space-y-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
               <div className="flex items-center justify-between mb-2">
                 <div className="flex items-center gap-2">
                   <ImageIcon className="h-4 w-4 text-primary-500" />
@@ -458,7 +458,7 @@ export function NewsDialog({ open, onOpenChange, onSubmit, news }: Props) {
             </div>
 
             {/* Attachments Selection */}
-            <div className="space-y-3 rounded-xl border border-border/60 bg-muted/30 p-4 shadow-sm">
+            <div className="space-y-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
               <div className="flex items-center justify-between mb-2">
                 <div className="flex items-center gap-2">
                   <FileText className="h-4 w-4 text-primary-500" />

--- a/backoffice/src/features/news/components/NewsFilters.tsx
+++ b/backoffice/src/features/news/components/NewsFilters.tsx
@@ -45,29 +45,28 @@ export function NewsFilters({
   };
 
   return (
-    <div className="mb-6 space-y-4">
-      {/* Primary Row: Search and Quick Status */}
+    <div className="mb-6 space-y-4 rounded-xl border border-slate-200 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
       <div className="flex flex-col gap-3 md:flex-row md:items-center">
         <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
           <Input
             placeholder="Buscar por título o contenido..."
             value={search}
             onChange={(e) => onSearch(e.target.value)}
-            className="pl-9 bg-card"
+            className="border-slate-300 bg-white pl-9 text-slate-700 dark:border-slate-700 dark:bg-slate-950"
           />
         </div>
 
-        <div className="inline-flex h-10 items-center gap-1 rounded-lg bg-muted/50 p-1">
+        <div className="inline-flex h-10 items-center gap-1 rounded-md border border-slate-200 bg-slate-50 p-1 dark:border-slate-700 dark:bg-slate-800/70">
           {statusTabs.map((tab) => (
             <button
               key={tab.value}
               onClick={() => onStatus(tab.value)}
               className={cn(
-                "rounded-md px-3 py-1.5 text-xs font-medium transition-all whitespace-nowrap",
+                "rounded-sm px-3 py-1.5 text-xs font-semibold transition-all whitespace-nowrap",
                 status === tab.value
-                  ? "bg-card text-foreground shadow-sm"
-                  : "text-muted-foreground hover:text-foreground",
+                  ? "bg-white text-primary-800 shadow-sm ring-1 ring-slate-200 dark:bg-slate-900 dark:text-primary-300 dark:ring-slate-700"
+                  : "text-slate-600 hover:text-slate-900 dark:text-slate-300 dark:hover:text-slate-100",
               )}
             >
               {tab.label}
@@ -76,15 +75,13 @@ export function NewsFilters({
         </div>
       </div>
 
-      {/* Secondary Row: Category Filter */}
       <div className="flex flex-wrap items-center gap-3">
-        {/* Category Dropdown */}
         <div className="flex items-center gap-2">
-          <Filter className="h-3.5 w-3.5 text-muted-foreground" />
+          <Filter className="h-3.5 w-3.5 text-slate-500" />
           <select
             value={selectedCategory}
             onChange={(e) => onCategory(e.target.value)}
-            className="h-8 rounded-full border border-border bg-card px-3 text-xs font-medium transition-all hover:border-primary/50 focus:outline-none focus:ring-2 focus:ring-primary/20"
+            className="h-8 rounded-md border border-slate-300 bg-white px-3 text-xs font-medium text-slate-700 transition-all hover:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200"
           >
             <option value="">Todas las categorías</option>
             {categories.map((cat) => (
@@ -95,27 +92,25 @@ export function NewsFilters({
           </select>
         </div>
 
-        {/* Clear Button */}
         {hasActiveFilters && (
           <Button
             variant="ghost"
             size="sm"
             onClick={clearFilters}
-            className="h-8 text-[11px] text-rose-600 hover:text-rose-700 hover:bg-rose-50"
+            className="h-8 text-[11px] text-rose-700 hover:bg-rose-50 hover:text-rose-800"
           >
             <X className="mr-1 h-3 w-3" /> Limpiar filtros
           </Button>
         )}
 
-        {/* Page Size (Compact) */}
-        <div className="ml-auto hidden md:flex items-center gap-2">
-          <Label className="text-[10px] uppercase tracking-wider text-muted-foreground">
+        <div className="ml-auto hidden items-center gap-2 md:flex">
+          <Label className="text-[10px] uppercase tracking-wider text-slate-500 dark:text-slate-400">
             Ver:
           </Label>
           <select
             value={pageSize}
             onChange={(e) => onPageSize(Number(e.target.value))}
-            className="h-7 rounded border border-border bg-card px-1.5 text-xs font-bold"
+            className="h-7 rounded border border-slate-300 bg-white px-1.5 text-xs font-semibold text-slate-700 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200"
           >
             {[10, 20, 50].map((size) => (
               <option key={size} value={size}>

--- a/backoffice/src/features/news/components/NewsTable.tsx
+++ b/backoffice/src/features/news/components/NewsTable.tsx
@@ -16,10 +16,10 @@ type Props = {
 
 export function NewsTable({ news, onEdit, onDelete }: Props) {
   return (
-    <div className="w-full overflow-hidden rounded-xl border border-border bg-card shadow-sm">
+    <div className="w-full overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
       <ScrollArea className="w-full">
         <table className="w-full min-w-[820px] table-auto caption-bottom text-sm">
-          <thead className="bg-muted/50 text-xs uppercase tracking-wide text-muted-foreground">
+          <thead className="bg-slate-50 text-xs uppercase tracking-[0.04em] text-slate-500 dark:bg-slate-800/50 dark:text-slate-400">
             <tr className="[&_th]:px-5 [&_th]:py-3 [&_th]:text-left [&_th]:font-semibold">
               <th>Titulo</th>
               <th>Categoria</th>
@@ -28,12 +28,12 @@ export function NewsTable({ news, onEdit, onDelete }: Props) {
               <th className="text-right">Acciones</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-border">
+          <tbody className="divide-y divide-slate-200 dark:divide-slate-800">
             {news.length === 0 ? (
               <tr>
                 <td
                   colSpan={5}
-                  className="p-6 text-center text-muted-foreground"
+                  className="p-6 text-center text-slate-500 dark:text-slate-400"
                 >
                   No hay noticias creadas.
                 </td>
@@ -42,20 +42,20 @@ export function NewsTable({ news, onEdit, onDelete }: Props) {
               news.map((item) => (
                 <tr
                   key={item.id}
-                  className="transition-colors hover:bg-muted/30"
+                  className="transition-colors hover:bg-slate-50/90 dark:hover:bg-slate-800/40"
                 >
                   <td className="px-5 py-4 align-middle">
                     <div className="flex items-start gap-3">
                       <NewsThumbnail news={item} />
                       <div className="space-y-1">
-                        <p className="font-semibold text-foreground">
+                        <p className="font-semibold text-slate-900 dark:text-slate-100">
                           {item.title}
                         </p>
-                        <p className="text-xs text-muted-foreground">
+                        <p className="text-xs text-slate-500 dark:text-slate-400">
                           {item.slug}
                         </p>
                         {item.excerpt && (
-                          <p className="text-xs text-muted-foreground line-clamp-2 max-w-md">
+                          <p className="max-w-md line-clamp-2 text-xs text-slate-500 dark:text-slate-400">
                             {item.excerpt}
                           </p>
                         )}
@@ -65,26 +65,29 @@ export function NewsTable({ news, onEdit, onDelete }: Props) {
 
                   <td className="px-5 py-4 align-middle">
                     {(item.category_name || item.category_slug) && (
-                      <Badge variant="outline">
+                      <Badge
+                        variant="outline"
+                        className="border-slate-300 text-slate-700 dark:border-slate-700 dark:text-slate-300"
+                      >
                         {item.category_name || item.category_slug}
                       </Badge>
                     )}
                   </td>
 
                   <td className="px-5 py-4 align-middle">
-                    <div className="flex items-center gap-2 text-sm text-foreground">
-                      <Calendar className="h-4 w-4 text-muted-foreground" />
+                    <div className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+                      <Calendar className="h-4 w-4 text-slate-400" />
                       <span>{formatDate(item.publish_date)}</span>
                     </div>
                   </td>
 
                   <td className="px-5 py-4 align-middle">
                     {item.is_published ? (
-                      <Badge className="bg-primary/10 text-primary hover:bg-primary/10 border-primary/20">
+                      <Badge className="border border-secondary-200 bg-secondary-50 text-secondary-700 hover:bg-secondary-50 dark:border-secondary-900 dark:bg-secondary-950/40 dark:text-secondary-300">
                         Publicado
                       </Badge>
                     ) : (
-                      <Badge className="bg-muted text-muted-foreground hover:bg-muted border-border">
+                      <Badge className="border border-slate-300 bg-slate-100 text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
                         Borrador
                       </Badge>
                     )}
@@ -95,7 +98,7 @@ export function NewsTable({ news, onEdit, onDelete }: Props) {
                       <Button
                         variant="ghost"
                         size="icon"
-                        className="h-8 w-8 text-muted-foreground hover:text-foreground hover:bg-muted"
+                        className="h-8 w-8 text-slate-500 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800"
                         onClick={() => onEdit(item)}
                         aria-label={`Editar ${item.title}`}
                       >
@@ -104,7 +107,7 @@ export function NewsTable({ news, onEdit, onDelete }: Props) {
                       <Button
                         variant="ghost"
                         size="icon"
-                        className="h-8 w-8 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+                        className="h-8 w-8 text-slate-500 hover:bg-rose-50 hover:text-rose-700 dark:text-slate-300 dark:hover:bg-rose-900/20 dark:hover:text-rose-300"
                         onClick={() => onDelete(item)}
                         aria-label={`Eliminar ${item.title}`}
                       >

--- a/backoffice/src/features/news/pages/NewsPage.tsx
+++ b/backoffice/src/features/news/pages/NewsPage.tsx
@@ -158,7 +158,11 @@ export function NewsPage() {
         title="Noticias"
         description="Gestiona las noticias publicadas y borradores"
         actions={
-          <Button onClick={handleCreate} size="sm">
+          <Button
+            onClick={handleCreate}
+            size="sm"
+            className="bg-primary-700 hover:bg-primary-800"
+          >
             <Plus className="mr-2 h-4 w-4" />
             Nueva noticia
           </Button>
@@ -189,14 +193,14 @@ export function NewsPage() {
         }}
       />
 
-      <Card className="border-border bg-card">
+      <Card className="border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
         <CardContent className="p-0">
           {loading ? (
-            <div className="flex h-48 items-center justify-center text-muted-foreground">
+            <div className="flex h-48 items-center justify-center text-slate-500 dark:text-slate-400">
               Cargando noticias...
             </div>
           ) : error ? (
-            <div className="flex h-48 items-center justify-center text-destructive">
+            <div className="flex h-48 items-center justify-center text-rose-700 dark:text-rose-300">
               {error}
             </div>
           ) : (
@@ -209,7 +213,7 @@ export function NewsPage() {
         </CardContent>
       </Card>
 
-      <div className="mt-4 flex flex-col gap-2 text-sm text-muted-foreground md:flex-row md:items-center md:justify-between">
+      <div className="mt-4 flex flex-col gap-2 text-sm text-slate-600 dark:text-slate-400 md:flex-row md:items-center md:justify-between">
         <span>
           Página {page} de {totalPages} • {filtered.length} resultados
         </span>

--- a/backoffice/src/index.css
+++ b/backoffice/src/index.css
@@ -1,26 +1,27 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Source+Sans+3:wght@400;500;600;700&display=swap");
 @import "tailwindcss";
 @config "../tailwind.config.js";
 
 @theme {
-  --font-sans: 'Inter', system-ui, sans-serif;
+  --font-sans: "Source Sans 3", "Inter", system-ui, sans-serif;
 }
 
 /* Base Styles */
 @layer base {
   body {
-    @apply bg-gray-50 text-gray-900 font-sans antialiased;
+    @apply bg-slate-100 text-slate-900 font-sans antialiased;
+    letter-spacing: 0.01em;
   }
 
   .dark body {
-    @apply bg-gray-900 text-gray-100;
+    @apply bg-slate-950 text-slate-100;
   }
 }
 
 /* Custom Scrollbar */
 ::-webkit-scrollbar {
-  width: 6px;
-  height: 6px;
+  width: 8px;
+  height: 8px;
 }
 
 ::-webkit-scrollbar-track {
@@ -28,16 +29,16 @@
 }
 
 ::-webkit-scrollbar-thumb {
-  @apply bg-gray-300 rounded-full dark:bg-gray-700;
+  @apply bg-slate-300 rounded-full dark:bg-slate-700;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  @apply bg-gray-400 dark:bg-gray-600;
+  @apply bg-slate-400 dark:bg-slate-500;
 }
 
 /* Tiptap specific styles */
 .tiptap p.is-editor-empty:first-child::before {
-  @apply text-gray-400 dark:text-gray-500 float-left h-0 pointer-events-none;
+  @apply text-slate-400 dark:text-slate-500 float-left h-0 pointer-events-none;
   content: attr(data-placeholder);
 }
 
@@ -50,5 +51,5 @@
 }
 
 .tiptap blockquote {
-  @apply border-l-4 border-gray-300 dark:border-gray-600 pl-4 italic;
+  @apply border-l-4 border-slate-300 dark:border-slate-600 pl-4 italic;
 }

--- a/backoffice/src/layouts/dashboard/DashboardLayout.tsx
+++ b/backoffice/src/layouts/dashboard/DashboardLayout.tsx
@@ -8,30 +8,28 @@ export default function DashboardLayout() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
   return (
-    <div className="flex h-screen w-full overflow-hidden bg-gray-50 dark:bg-gray-900">
-      {/* Mobile Sidebar Overlay */}
+    <div className="flex h-screen w-full overflow-hidden bg-slate-100 dark:bg-slate-950">
       {isSidebarOpen && (
         <div
-          className="fixed inset-0 z-40 bg-gray-900/50 backdrop-blur-sm lg:hidden"
+          className="fixed inset-0 z-40 bg-slate-950/45 backdrop-blur-[1px] lg:hidden"
           onClick={() => setIsSidebarOpen(false)}
         />
       )}
 
-      {/* Sidebar Container */}
-      <div className={`
-        fixed inset-y-0 left-0 z-50 flex h-full transform transition-transform duration-300 ease-in-out lg:static lg:translate-x-0
+      <div
+        className={`
+        fixed inset-y-0 left-0 z-50 flex h-full transform transition-transform duration-200 ease-out lg:static lg:translate-x-0
         ${isSidebarOpen ? "translate-x-0" : "-translate-x-full"}
-      `}>
+      `}
+      >
         <Sidebar />
       </div>
 
-      {/* Main Content Wrapper */}
-      <div className="flex flex-1 flex-col overflow-hidden min-w-0">
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
         <Header onMenuClick={() => setIsSidebarOpen(true)} />
 
-        <main className="flex-1 overflow-y-auto overflow-x-hidden p-4 md:p-6 lg:p-8 custom-scrollbar flex flex-col items-center">
-          {/* Content Container - Centered and constrained */}
-          <div className="w-full max-w-7xl mx-auto animate-in fade-in duration-300">
+        <main className="custom-scrollbar flex flex-1 flex-col items-center overflow-y-auto overflow-x-hidden px-4 py-4 md:px-6 md:py-6 lg:px-8 lg:py-8">
+          <div className="mx-auto w-full max-w-7xl animate-in fade-in duration-200">
             <Outlet />
           </div>
         </main>

--- a/backoffice/src/layouts/dashboard/Header.tsx
+++ b/backoffice/src/layouts/dashboard/Header.tsx
@@ -15,44 +15,39 @@ export function Header({ onMenuClick }: HeaderProps) {
   const { theme, setTheme } = useTheme();
 
   return (
-    <header className="sticky top-0 z-30 flex h-16 w-full items-center justify-between border-b border-gray-200 bg-white/80 px-6 backdrop-blur-md transition-colors duration-300 dark:border-gray-800 dark:bg-gray-900/80">
-      {/* Left section: Breadcrumbs / Mobile Menu */}
+    <header className="sticky top-0 z-30 flex h-16 w-full items-center justify-between border-b border-slate-200 bg-white/95 px-4 backdrop-blur-sm transition-colors duration-200 dark:border-slate-800 dark:bg-slate-950/90 md:px-6">
       <div className="flex items-center gap-4">
         <button
           onClick={onMenuClick}
-          className="rounded-md p-2 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800 lg:hidden"
+          className="rounded-md p-2 text-slate-500 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800 lg:hidden"
         >
           <Menu className="h-5 w-5" />
         </button>
 
-        {/* Search Bar (Visual only for now) */}
         <div className="hidden md:block">
           <div className="relative">
-            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-gray-400" />
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
             <input
               type="text"
               placeholder="Buscar..."
-              className="h-9 w-64 rounded-full border-gray-200 bg-gray-50 pl-9 text-sm text-gray-900 focus:border-primary-500 focus:ring-primary-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:placeholder-gray-400"
+              className="h-9 w-72 rounded-md border border-slate-200 bg-slate-50 pl-9 text-sm text-slate-700 placeholder:text-slate-400 focus:border-primary-500 focus:ring-primary-500 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
             />
           </div>
         </div>
       </div>
 
-      {/* Right section: Actions & Profile */}
       <div className="flex items-center gap-1 sm:gap-2">
-        {/* Notifications */}
         <Tooltip content="Notificaciones">
-          <button className="relative rounded-full p-2.5 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500/20">
+          <button className="relative rounded-md p-2.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-50 focus:outline-none focus:ring-2 focus:ring-primary-500/20">
             <Bell className="h-5 w-5" />
-            <span className="absolute right-2.5 top-2.5 h-2 w-2 rounded-full bg-red-500 ring-2 ring-white dark:ring-gray-900"></span>
+            <span className="absolute right-2.5 top-2.5 h-2 w-2 rounded-full bg-secondary-500 ring-2 ring-white dark:ring-slate-900"></span>
           </button>
         </Tooltip>
 
-        {/* Theme Toggle */}
         <Tooltip content={theme === "dark" ? "Modo claro" : "Modo oscuro"}>
           <button
             onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-            className="rounded-full p-2.5 text-gray-500 transition-colors hover:bg-gray-100 hover:text-amber-500 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-amber-400 focus:outline-none focus:ring-2 focus:ring-primary-500/20"
+            className="rounded-md p-2.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-primary-700 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-primary-300 focus:outline-none focus:ring-2 focus:ring-primary-500/20"
           >
             {theme === "dark" ? (
               <Sun className="h-5 w-5" />
@@ -62,15 +57,14 @@ export function Header({ onMenuClick }: HeaderProps) {
           </button>
         </Tooltip>
 
-        <div className="mx-2 h-6 w-px bg-gray-200 dark:bg-gray-700"></div>
+        <div className="mx-2 h-6 w-px bg-slate-200 dark:bg-slate-700"></div>
 
-        {/* User Profile */}
         <div className="flex items-center gap-3">
           <div className="hidden text-right md:block">
-            <p className="text-sm font-medium text-gray-900 dark:text-white">
+            <p className="text-sm font-semibold text-slate-900 dark:text-slate-100">
               {user?.username || "Usuario"}
             </p>
-            <p className="text-xs text-gray-500 dark:text-gray-400">
+            <p className="text-xs text-slate-500 dark:text-slate-400">
               Administrador
             </p>
           </div>
@@ -85,13 +79,12 @@ export function Header({ onMenuClick }: HeaderProps) {
               className="cursor-pointer transition-transform hover:scale-105"
             />
 
-            {/* Simple Dropdown Stub (Flowbite Dropdown had issues with stubs) */}
-            <div className="invisible absolute right-0 top-full mt-2 w-48 translate-y-2 opacity-0 shadow-lg transition-all group-hover:visible group-hover:translate-y-0 group-hover:opacity-100 z-50">
-              <div className="overflow-hidden rounded-lg border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+            <div className="invisible absolute right-0 top-full z-50 mt-2 w-48 translate-y-1 opacity-0 shadow-lg transition-all group-hover:visible group-hover:translate-y-0 group-hover:opacity-100">
+              <div className="overflow-hidden rounded-md border border-slate-200 bg-white dark:border-slate-700 dark:bg-slate-900">
                 <div className="p-2">
                   <button
                     onClick={logout}
-                    className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
+                    className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm text-rose-700 hover:bg-rose-50 dark:text-rose-300 dark:hover:bg-rose-900/20"
                   >
                     <LogOut className="h-4 w-4" />
                     Cerrar sesión

--- a/backoffice/src/layouts/dashboard/Sidebar.tsx
+++ b/backoffice/src/layouts/dashboard/Sidebar.tsx
@@ -76,11 +76,11 @@ export function Sidebar() {
   }) => (
     <div className="mb-6">
       {title && (
-        <h3 className="mb-2 px-4 text-[10px] font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+        <h3 className="mb-2 px-4 text-[10px] font-semibold uppercase tracking-[0.08em] text-slate-500 dark:text-slate-400">
           {title}
         </h3>
       )}
-      <div className="space-y-0.5 px-2">
+      <div className="space-y-1 px-2">
         {items.map((item) => {
           const isActive = location.pathname === item.href;
           const Icon = item.icon;
@@ -88,17 +88,17 @@ export function Sidebar() {
             <Link
               key={item.name}
               to={item.href}
-              className={`group flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium transition-all duration-200 ${
+              className={`group flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium transition-colors duration-150 ${
                 isActive
-                  ? "bg-primary-50 text-primary-700 dark:bg-primary-500/10 dark:text-primary-300 shadow-sm ring-1 ring-primary-200 dark:ring-transparent"
-                  : "text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-50"
+                  ? "bg-primary-50 text-primary-800 ring-1 ring-primary-200 dark:bg-primary-950/50 dark:text-primary-200 dark:ring-primary-900"
+                  : "text-slate-700 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-slate-800 dark:hover:text-slate-100"
               }`}
             >
               <Icon
-                className={`h-5 w-5 shrink-0 transition-colors ${
+                className={`h-4 w-4 shrink-0 transition-colors ${
                   isActive
-                    ? "text-primary-600 dark:text-primary-400"
-                    : "text-gray-400 group-hover:text-gray-600 dark:text-gray-500 dark:group-hover:text-gray-300"
+                    ? "text-primary-700 dark:text-primary-300"
+                    : "text-slate-400 group-hover:text-slate-600 dark:text-slate-500 dark:group-hover:text-slate-300"
                 }`}
               />
               {item.name}
@@ -110,17 +110,15 @@ export function Sidebar() {
   );
 
   return (
-    <aside className="flex h-screen w-[260px] shrink-0 flex-col border-r border-gray-200 bg-white dark:bg-gray-900 dark:border-gray-800 transition-colors duration-300">
-      {/* Brand Header */}
-      <div className="flex h-24 items-center justify-center border-b border-gray-100 px-6 dark:border-gray-800">
-        <div className="flex h-[3.75rem] w-[7.5rem] items-center justify-center rounded-lg bg-primary/10 p-2">
-          <span className="text-xl font-bold text-primary-600 dark:text-primary-400">
-            GAUDEIX
+    <aside className="flex h-screen w-[264px] shrink-0 flex-col border-r border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900 transition-colors duration-200">
+      <div className="flex h-20 items-center border-b border-slate-200 px-6 dark:border-slate-800">
+        <div className="inline-flex items-center gap-2 rounded-md border border-primary-200 bg-primary-50 px-3 py-2 dark:border-primary-900 dark:bg-primary-950/40">
+          <span className="text-sm font-semibold tracking-[0.08em] text-primary-800 dark:text-primary-300">
+            GAUDEIX CODEx
           </span>
         </div>
       </div>
 
-      {/* Navigation */}
       <nav className="custom-scrollbar flex-1 overflow-y-auto py-6">
         <NavSection title="Dashboard" items={panelNavigation} />
         <NavSection title="Gestión de Contenido" items={contentNavigation} />
@@ -132,18 +130,14 @@ export function Sidebar() {
         />
       </nav>
 
-      {/* Footer Info */}
-      <div className="border-t border-gray-100 p-4 dark:border-gray-800">
-        <div className="rounded-lg bg-gray-50 p-3 text-xs text-gray-500 dark:bg-gray-800/50 dark:text-gray-400">
-          <p className="font-medium text-gray-900 dark:text-gray-200">
+      <div className="border-t border-slate-200 p-4 dark:border-slate-800">
+        <div className="rounded-md bg-slate-50 p-3 text-xs text-slate-600 dark:bg-slate-800/70 dark:text-slate-300">
+          <p className="font-semibold text-slate-900 dark:text-slate-100">
             Estado del Sistema
           </p>
           <div className="mt-2 flex items-center gap-2">
-            <span className="relative flex h-2 w-2">
-              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75"></span>
-              <span className="relative inline-flex h-2 w-2 rounded-full bg-green-500"></span>
-            </span>
-            <span className="text-[10px]">Todos los servicios operativos</span>
+            <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-secondary-500" />
+            <span className="text-[11px]">Todos los servicios operativos</span>
           </div>
         </div>
       </div>

--- a/backoffice/tailwind.config.js
+++ b/backoffice/tailwind.config.js
@@ -4,57 +4,54 @@ module.exports = {
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
-    "node_modules/flowbite-react/**/*.{js,jsx,ts,tsx}"
+    "node_modules/flowbite-react/**/*.{js,jsx,ts,tsx}",
   ],
   theme: {
     extend: {
       colors: {
-        // Indigo Palette (Professional, Trustworthy) - Replaces green
+        // Municipal palette (institutional, trustworthy, sober)
         primary: {
-          50: '#eef2ff',
-          100: '#e0e7ff',
-          200: '#c7d2fe',
-          300: '#a5b4fc',
-          400: '#818cf8',
-          500: '#6366f1',
-          600: '#4f46e5',
-          700: '#4338ca',
-          800: '#3730a3',
-          900: '#312e81',
-          950: '#1e1b4b',
+          50: "#f0f6fb",
+          100: "#d9e9f5",
+          200: "#b5d3e9",
+          300: "#89b7d9",
+          400: "#5e9bc8",
+          500: "#3f82b5",
+          600: "#326b97",
+          700: "#2a5578",
+          800: "#254865",
+          900: "#213d55",
+          950: "#152739",
         },
-        // Secondary/Accent - Cyan
+        // Secondary accent (soft civic green)
         secondary: {
-          50: '#ecfeff',
-          100: '#cffafe',
-          200: '#a5f3fc',
-          300: '#67e8f9',
-          400: '#22d3ee',
-          500: '#06b6d4',
-          600: '#0891b2',
-          700: '#0e7490',
-          800: '#155e75',
-          900: '#164e63',
+          50: "#f1f7f4",
+          100: "#dcece3",
+          200: "#badac7",
+          300: "#8fc1a5",
+          400: "#66a985",
+          500: "#4c936f",
+          600: "#3b7659",
+          700: "#315e49",
+          800: "#2b4c3c",
+          900: "#243f32",
         },
       },
       fontFamily: {
         sans: [
-          'Inter', 
-          'ui-sans-serif', 
-          'system-ui', 
-          '-apple-system', 
-          'system-ui', 
-          'Segoe UI', 
-          'Roboto', 
-          'Helvetica Neue', 
-          'Arial', 
-          'sans-serif'
+          "Inter",
+          "ui-sans-serif",
+          "system-ui",
+          "-apple-system",
+          "system-ui",
+          "Segoe UI",
+          "Roboto",
+          "Helvetica Neue",
+          "Arial",
+          "sans-serif",
         ],
-      }
+      },
     },
   },
-  plugins: [
-    require("flowbite/plugin"),
-    require("@tailwindcss/typography")
-  ],
+  plugins: [require("flowbite/plugin"), require("@tailwindcss/typography")],
 };


### PR DESCRIPTION
### Motivation
- Apply a non‑aggressive visual refresh to the backoffice to convey a municipal/corporate identity while keeping current UX and flows intact.  
- Improve legibility, contrast and hierarchy for daily operational use without changing behavior, routes, APIs or permissions.  
- Standardize tokens (colors, typography, spacings, radii, shadows) and iconography to increase consistency and accessibility (WCAG AA target).  

### Description
- Updated design tokens and global base styles by changing the Tailwind palette (`backoffice/tailwind.config.js`) to a sober `primary` (blue civic) and `secondary` (soft civic green) and switching the base font to `Source Sans 3` in `backoffice/src/index.css`.  
- Applied the visual language across the dashboard shell and key screens by restyling `Sidebar`, `Header`, `DashboardLayout`, `DashboardHome`, `StatCard` and news screens (`NewsPage`, `NewsFilters`, `NewsTable`, `NewsDialog`) to use the new tokens and cleaner surfaces without modifying logic.  
- Reworked smaller UI affordances (scrollbar size, spacing, badge/button/checkbox appearances, subtle hover elevations and reduced animation) to be more discreet and corporate while preserving component APIs.  
- Added a concise deliverable document `UX/backoffice-visual-refresh.md` with the conceptual guide, token proposal, screen applications, before/after rationale and a no‑breaking checklist.  

### Testing
- Built the backoffice frontend with `npm run --prefix backoffice build` which completed successfully (TypeScript + Vite build passed, CSS minify warnings only).  
- Started the dev server with `npm run --prefix backoffice dev` and captured a Playwright screenshot to validate the visual changes (artifact generated).  
- Pre-commit hooks ran `prettier` and `pnpm exec vitest related --run --passWithNoTests` via `lint-staged` during the commit and completed successfully; note that there is no project `lint` npm script so `npm run --prefix backoffice lint` is not applicable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a99cb8a87c83279dd7695efb907b3f)