### PR TITLE
Fix Playas: legacy redirect, update links and comparison gating

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ import { EventDetailPage } from "@/features/agenda/pages/EventDetailPage";
 import { AgendaPage } from "@/features/agenda/pages/AgendaPage";
 import { PlacesPage } from "@/features/places/pages/PlacesPage";
 import { PlaceDetailPage } from "@/features/places/pages/PlaceDetailPage";
+import { LegacyBeachPlaceRedirect } from "@/features/places/pages/LegacyBeachPlaceRedirect";
 import { RankingsPage } from "@/features/gamification/pages/RankingsPage";
 import { CategoriesPage } from "@/features/categories/pages/CategoriesPage";
 import { CategoryDetailPage } from "@/features/categories/pages/CategoryDetailPage";
@@ -400,7 +401,8 @@ export default function App() {
         <Route path="/agenda" element={<AgendaPage />} />
         <Route path="/agenda/:slug" element={<EventDetailPage />} />
         <Route path="/lugares" element={<PlacesPage />} />
-        <Route path="/lugares/:slug" element={<PlaceDetailPage />} />
+        <Route path="/lugares/:slug" element={<LegacyBeachPlaceRedirect />} />
+        <Route path="/playas/:slug" element={<PlaceDetailPage />} />
         <Route path="/categorias" element={<CategoriesPage />} />
         <Route path="/categorias/:slug" element={<CategoryDetailPage />} />
         <Route path="/rankings" element={<RankingsPage />} />

--- a/frontend/src/data/headerNav.ts
+++ b/frontend/src/data/headerNav.ts
@@ -13,7 +13,7 @@ export const HEADER_NAV: HeaderNavItem[] = [
       { label: "Categorías", href: "/categorias" },
       { label: "Patrimonio", href: "/lugares?category=heritage" },
       { label: "Naturaleza", href: "/lugares?category=nature" },
-      { label: "Playas", href: "/lugares?category=beaches" },
+      { label: "Playas", href: "/categorias/beaches" },
       { label: "Cultura", href: "/lugares?category=culture" },
       { label: "Gastronomía", href: "/lugares?category=restaurants" },
       { label: "Alojamiento", href: "/lugares?category=accommodations" },

--- a/frontend/src/features/categories/templates/layouts/NatureCategoryLayout.test.tsx
+++ b/frontend/src/features/categories/templates/layouts/NatureCategoryLayout.test.tsx
@@ -1,0 +1,86 @@
+import type { ReactNode } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+import NatureCategoryLayout from "./NatureCategoryLayout";
+
+vi.mock("@/components/animated/MotionReveal", () => ({
+  MotionReveal: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/features/places/components/PlaceCard", () => ({
+  PlaceCard: ({ place }: { place: { title: string } }) => <div>{place.title}</div>,
+}));
+
+const baseCategory = {
+  id: 1,
+  slug: "beaches",
+  nombre: "Playas",
+  descripcion: "Descubre nuestras playas",
+  taxonomy: "places",
+  parent: null,
+  icon: "umbrella",
+  is_published: true,
+  featured_media: null,
+  attachments: [],
+  created_at: "2025-01-01",
+  updated_at: "2025-01-01",
+};
+
+const makePlace = (id: number) => ({
+  id,
+  slug: `playa-${id}`,
+  title: `Playa ${id}`,
+  description: "",
+  location_text: `Zona ${id}`,
+  latitude: 41,
+  longitude: 2,
+  phone: id === 1 ? "123" : "",
+  email: "",
+  website: "",
+  booking_url: "",
+  is_published: true,
+  category: 1,
+  template_key: "beaches",
+  featured_media: null,
+  attachments: [],
+  created_at: "2025-01-01",
+  updated_at: "2025-01-01",
+});
+
+describe("NatureCategoryLayout beaches comparison", () => {
+  it("shows comparison only when exactly two beaches are available", () => {
+    render(
+      <MemoryRouter>
+        <NatureCategoryLayout
+          category={baseCategory as any}
+          places={[makePlace(1), makePlace(2)] as any}
+          events={[] as any}
+          isLoadingPlaces={false}
+          isLoadingEvents={false}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Compara las dos playas publicadas")).toBeInTheDocument();
+    expect(screen.queryByText("Seleccion editorial")).not.toBeInTheDocument();
+  });
+
+  it("shows editorial fallback when published beaches are not exactly two", () => {
+    render(
+      <MemoryRouter>
+        <NatureCategoryLayout
+          category={baseCategory as any}
+          places={[makePlace(1), makePlace(2), makePlace(3), makePlace(4)] as any}
+          events={[] as any}
+          isLoadingPlaces={false}
+          isLoadingEvents={false}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Seleccion editorial")).toBeInTheDocument();
+    expect(screen.queryByText("Compara las dos playas publicadas")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/categories/templates/layouts/NatureCategoryLayout.tsx
+++ b/frontend/src/features/categories/templates/layouts/NatureCategoryLayout.tsx
@@ -90,7 +90,7 @@ export default function NatureCategoryLayout({
                 </div>
 
                 <Link
-                  to={`/lugares?category=${category.slug}`}
+                  to={`/categorias/${category.slug}`}
                   className="inline-flex items-center gap-2 rounded-full border border-primary/12 bg-primary/5 px-4 py-2.5 text-sm font-semibold text-primary"
                 >
                   <Map className="h-4 w-4" />
@@ -139,6 +139,48 @@ export default function NatureCategoryLayout({
             </AnimatedCardGrid>
           )}
         </section>
+
+        {category.slug === "beaches" ? (
+          <MotionReveal>
+            {places.length === 2 ? (
+              <section className="card-surface space-y-6 p-6 md:p-8">
+                <SectionHeader
+                  eyebrow="Comparativa"
+                  title="Compara las dos playas publicadas"
+                  description="Vista rapida para decidir cual visitar segun ubicacion y contacto disponible."
+                />
+                <div className="overflow-x-auto">
+                  <table className="min-w-full text-left text-sm text-slate-700">
+                    <thead>
+                      <tr className="border-b border-slate-200 text-xs uppercase tracking-[0.14em] text-slate-500">
+                        <th className="px-3 py-3">Playa</th>
+                        <th className="px-3 py-3">Ubicacion</th>
+                        <th className="px-3 py-3">Telefono</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {places.map((place) => (
+                        <tr key={place.id} className="border-b border-slate-100 last:border-b-0">
+                          <td className="px-3 py-3 font-semibold text-slate-900">{place.title}</td>
+                          <td className="px-3 py-3">{place.location_text}</td>
+                          <td className="px-3 py-3">{place.phone || "-"}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+            ) : (
+              <section className="card-surface space-y-4 p-6 md:p-8">
+                <SectionHeader
+                  eyebrow="Seleccion editorial"
+                  title="El equipo municipal destaca las mejores opciones para hoy"
+                  description="Cuando hay mas o menos de dos playas publicadas, mostramos una narrativa editorial en lugar de forzar una comparativa."
+                />
+              </section>
+            )}
+          </MotionReveal>
+        ) : null}
 
         {places.length === 0 && !isLoadingPlaces ? (
           <div className="py-24 text-center">

--- a/frontend/src/features/hero/components/HomeExperienceGrid.tsx
+++ b/frontend/src/features/hero/components/HomeExperienceGrid.tsx
@@ -39,7 +39,7 @@ const EXPERIENCES: ExperienceItem[] = [
     },
     {
         title: "Playas",
-        href: "/lugares?category=beaches",
+        href: "/categorias/beaches",
         iconKey: "beaches",
         color: "text-[#3EC5FF]",
         bg: "bg-[#3EC5FF]/16 ring-[#3EC5FF]/40",

--- a/frontend/src/features/hero/components/HomePillars.tsx
+++ b/frontend/src/features/hero/components/HomePillars.tsx
@@ -46,7 +46,7 @@ const PILLARS: PillarItem[] = [
     },
     {
         title: "Platges",
-        href: "/lugares?category=beaches",
+        href: "/categorias/beaches",
         icon: Umbrella,
         color: "bg-[#3EC5FF]",
         lightColor: "hover:bg-[#3EC5FF]/90",

--- a/frontend/src/features/places/pages/LegacyBeachPlaceRedirect.tsx
+++ b/frontend/src/features/places/pages/LegacyBeachPlaceRedirect.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useNavigate, useParams } from "react-router-dom";
+
+import { getPlaces } from "../api";
+import { PlaceDetailPage } from "./PlaceDetailPage";
+
+export function LegacyBeachPlaceRedirect() {
+  const { slug } = useParams<{ slug: string }>();
+  const navigate = useNavigate();
+
+  const { data: isBeachSlug, isLoading } = useQuery({
+    queryKey: ["legacy-beach-redirect", slug],
+    queryFn: async () => {
+      if (!slug) return false;
+      const response = await getPlaces({ category: "beaches", is_published: true, limit: 200 });
+      const beaches = Array.isArray(response) ? response : response.results || [];
+      return beaches.some((place) => place.slug === slug);
+    },
+    enabled: !!slug,
+  });
+
+  useEffect(() => {
+    if (isBeachSlug && slug) {
+      navigate(`/playas/${slug}`, { replace: true });
+    }
+  }, [isBeachSlug, navigate, slug]);
+
+  if (isLoading) {
+    return <div className="page-shell-offset" />;
+  }
+
+  return <PlaceDetailPage />;
+}


### PR DESCRIPTION
### Motivation
- Restaurar compatibilidad con URLs antiguas de playas redirigiendo `/lugares/:slug` a la nueva ruta `/playas/:slug` cuando corresponda para evitar 404s y pérdida SEO. 
- Eliminar enlaces obsoletos que apuntaban a `/lugares?category=beaches` para que apunten a la nueva navegación por categorías en `/categorias/beaches`.
- Controlar la visualización de la comparativa de playas para que solo se muestre cuando haya exactamente dos playas publicadas y mostrar un fallback editorial en caso contrario.

### Description
- Añadida la ruta/logic de compatibilidad `LegacyBeachPlaceRedirect` en `frontend/src/features/places/pages/LegacyBeachPlaceRedirect.tsx` que consulta playas publicadas y redirige a `/playas/:slug` cuando el slug pertenece a la categoría `beaches`.
- Registrada la ruta explícita `/playas/:slug` y sustituida la ruta legacy en el router de la app en `frontend/src/App.tsx` para preservar comportamiento y nueva URL.
- Reemplazados enlaces globales que apuntaban a `/lugares?category=beaches` por `/categorias/beaches` en `frontend/src/data/headerNav.ts`, `frontend/src/features/hero/components/HomeExperienceGrid.tsx` y `frontend/src/features/hero/components/HomePillars.tsx`.
- Modificada la plantilla de categoría `NatureCategoryLayout` (`frontend/src/features/categories/templates/layouts/NatureCategoryLayout.tsx`) para mostrar la tabla comparativa solo cuando `places.length === 2` y, en cualquier otro caso para la categoría `beaches`, renderizar un bloque editorial de fallback.
- Añadidos tests de regresión `frontend/src/features/categories/templates/layouts/NatureCategoryLayout.test.tsx` que validan la regla de comparativa vs fallback.

### Testing
- Ejecutados los tests unitarios dirigidos con `npm test --prefix frontend -- src/features/categories/templates/layouts/NatureCategoryLayout.test.tsx src/features/places/pages/PlaceDetailPage.test.tsx --run`, ambos archivos pasaron (7 tests en total).
- Ejecutado el type-check con `npm run --prefix frontend type-check`, la comprobación TypeScript (`tsc --noEmit`) finalizó sin errores.
- Ejecutado ESLint con `npm run --prefix frontend lint` sobre los ficheros tocados, que devolvió advertencias pero no errores de bloqueo.
- Validación visual automática con Playwright generó una captura de la página de categoría en `artifacts/playas-category.png` para verificación visual del layout y enlaces.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af6317f404832780ce5a3fb65379bf)