### PR TITLE
Fix Dokploy deploy contract

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -30,4 +30,4 @@ jobs:
             --request POST "${DOKPLOY_URL%/}/api/compose.deploy" \
             --header "x-api-key: $DOKPLOY_API_KEY" \
             --header "Content-Type: application/json" \
-            --data "{\"json\":{\"composeId\":\"$COMPOSE_ID\",\"title\":\"GitHub Actions deploy\",\"description\":\"Ref: ${{ inputs.ref }}\"}}"
+            --data "{\"composeId\":\"$COMPOSE_ID\",\"title\":\"GitHub Actions deploy\",\"description\":\"Ref: ${{ inputs.ref }}\"}"

--- a/docker-compose.dokploy.yml
+++ b/docker-compose.dokploy.yml
@@ -6,10 +6,7 @@ services:
     command: >
       sh -c "python manage.py migrate --noinput &&
              python manage.py collectstatic --noinput &&
-             gunicorn gaudeix_backend.wsgi:application
-             --bind 0.0.0.0:8000
-             --workers $${GUNICORN_WORKERS:-3}
-             --timeout $${GUNICORN_TIMEOUT:-120}"
+             exec gunicorn gaudeix_backend.wsgi:application --bind 0.0.0.0:8000 --workers $${GUNICORN_WORKERS:-3} --timeout $${GUNICORN_TIMEOUT:-120}"
     environment:
       ENVIRONMENT: production
       DEBUG: "false"
@@ -76,6 +73,8 @@ services:
       - gaudeix_media:/app/media
     networks:
       - dokploy-network
+    healthcheck:
+      disable: true
     restart: unless-stopped
 
   beat:
@@ -111,6 +110,8 @@ services:
       - gaudeix_media:/app/media
     networks:
       - dokploy-network
+    healthcheck:
+      disable: true
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Summary
- send the Dokploy compose deploy payload in the flat JSON shape accepted by the production API
- keep the backend gunicorn command on one shell line so it binds to 0.0.0.0 for Traefik
- disable the inherited HTTP healthcheck for worker and beat services

## Tests
- docker compose -f docker-compose.dokploy.yml config --quiet