### PR TITLE
Add seed runtime dependency

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -51,6 +51,7 @@ mistralai==1.2.4
 groq==0.13.0
 
 # Utilities
+Faker==40.1.2
 PyYAML==6.0.3
 packaging==25.0
 inflection==0.5.1


### PR DESCRIPTION
## Summary
- move Faker into production requirements because seed_all imports it during controlled production bootstrap

## Tests
- python -m pip install -r backend/requirements.txt --dry-run