### PR TITLE
[codex] Fix Pages deep links

### DIFF
--- a/scripts/prepare-pages-artifact.mjs
+++ b/scripts/prepare-pages-artifact.mjs
@@ -20,7 +20,20 @@ await cp(
   path.join(backofficeOutput, "404.html"),
 );
 
-const frontendRouteEntries = ["festes/programacio", "historias"];
+const frontendRouteEntries = [
+  "agenda",
+  "categorias",
+  "como-llegar",
+  "festes",
+  "festes/programacio",
+  "historias",
+  "lugares",
+  "mis-favoritos",
+  "noticias",
+  "rankings",
+  "rutas",
+  "rutas/roadmap",
+];
 
 for (const route of frontendRouteEntries) {
   const routeOutputDir = path.join(outputDir, route);


### PR DESCRIPTION
﻿## Summary

This follow-up fixes GitHub Pages deep links for the newly verified production routes. The first production smoke after merging PR #151 showed that `/festes/` and `/rutas/` returned 404 because the Pages artifact only created explicit entries for `/historias/` and `/festes/programacio/`.

## Fix

The Pages artifact preparation script now writes explicit `index.html` entries for public top-level routes such as agenda, categories, festes, rutas, places, news, rankings, and related paths. This preserves SPA routing while returning HTTP 200 for direct GitHub Pages navigation.

## Validation

- `pnpm build:pages`
- `pnpm lint`
